### PR TITLE
CI: reenable tests, disable formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,4 @@ jobs:
 
       - name: Build and test with CMake/lit
         run: |
-
-          pushd build && ninja check-tamagoyaki && popd
-          rm -rf build
+          cmake --build build --target check-tamagoyaki


### PR DESCRIPTION
Formatting is disabled until https://github.com/jidicula/clang-format-action/issues/267 is resolved