### PR TITLE
Fix `repair`

### DIFF
--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -73,7 +73,12 @@ LogicalResult ClassOp::verify() {
     return emitOpError("must have at least one operand");
   }
 
+  SmallPtrSet<Value, 8> seen;
   for (Value operand : getInputs()) {
+    if (!seen.insert(operand).second) {
+      return emitOpError("operands must be unique");
+    }
+
     Operation *defOp = operand.getDefiningOp();
     if (defOp && isa<ClassOp>(defOp)) {
       return emitOpError("result of a class operation cannot be used as an "

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 #include <cassert>
 #include <cstddef>
 #include <type_traits>
@@ -288,6 +289,7 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
     Operation *op2 = uniqueParents.lookup(op1);
 
     if (op2) {
+      assert(op2->getBlock());
       if (scheduledForMerge.insert(op1).second)
         toMerge.emplace_back(op1, op2);
     } else {
@@ -295,31 +297,46 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
     }
   }
   // Now perform all merges after we're done with the hash map
-  for (auto [op1, op2] : toMerge) {
-    if (op1 == op2)
+  for (auto [other, keep] : toMerge) {
+    if (keep == other)
       continue;
-    // Collect eclass pairs before replacement
-    auto [keep, other] =
-        rewriter.lookup(op1) == op1 ? std::pair{op1, op2} : std::pair{op2, op1};
-    for (auto [resKeep, resOther] :
-         llvm::zip(keep->getResults(), other->getResults())) {
+
+    bool erased = rewriter.erase(keep).succeeded();
+    assert(erased);
+    bool inserted = rewriter.insert(keep).succeeded();
+    assert(inserted);
+
+    for (auto [resOther, resKeep] :
+         llvm::zip_equal(other->getResults(), keep->getResults())) {
+      // Collect eclass pairs before replacement
       equivalence::ClassOp classKeep = getClassOpIfExists(resKeep);
       equivalence::ClassOp classOther = getClassOpIfExists(resOther);
-      rewriter.replaceAllUsesWith(resOther, resKeep);
-      if (classKeep == nullptr || classOther == nullptr) {
-        continue;
-      }
-      if (classKeep != classOther) {
-        classUnion(rewriter, classKeep.getResult(), classOther.getResult());
-      } else {
-        SmallPtrSet<Value, 8> seen;
-        SmallVector<Value> uniqueOperands;
-        for (Value operand : classKeep.getInputs()) {
-          if (seen.insert(operand).second)
-            uniqueOperands.push_back(operand);
+
+      if (classKeep && classOther) {
+        // Case 1: both values have a class — replace other's results with
+        // keep's results, then union the two classes.
+        rewriter.replaceAllUsesWith(resOther, resKeep);
+        if (classKeep != classOther) {
+          classUnion(rewriter, classKeep.getResult(), classOther.getResult());
+        } else {
+          SmallPtrSet<Value, 8> seen;
+          SmallVector<Value> uniqueOperands;
+          for (Value operand : classKeep.getInputs()) {
+            if (seen.insert(operand).second)
+              uniqueOperands.push_back(operand);
+          }
+          classKeep.getInputsMutable().assign(uniqueOperands);
         }
-        classKeep.getInputsMutable().assign(uniqueOperands);
+      } else if (classKeep) {
+        // Case 2: only keep has a class — redirect other's results to the
+        // class representative rather than the raw result.
+        rewriter.replaceAllUsesWith(resOther, classKeep.getResult());
+      } else {
+        // Case 3 (only other has a class) & Case 4 (neither has a class):
+        // replace other's results with keep's results.
+        rewriter.replaceAllUsesWith(resOther, resKeep);
       }
     }
+    rewriter.eraseOp(other);
   }
 }

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -33,12 +33,181 @@
 using namespace mlir;
 using namespace mlir::ematch;
 
+namespace {
+
+bool classInputsAreUnique(equivalence::ClassOp classOp) {
+  SmallPtrSet<Value, 8> seen;
+  for (Value operand : classOp.getInputs()) {
+    if (!seen.insert(operand).second)
+      return false;
+  }
+  return true;
+}
+
+Value findFirstDuplicateInput(equivalence::ClassOp classOp) {
+  SmallPtrSet<Value, 8> seen;
+  for (Value operand : classOp.getInputs()) {
+    if (!seen.insert(operand).second)
+      return operand;
+  }
+  return {};
+}
+
+void logFirstDuplicateOnly(llvm::StringRef label, equivalence::ClassOp classOp,
+                           Value duplicateOperand = {}) {
+  static bool emitted = false;
+  if (emitted)
+    return;
+
+  if (!duplicateOperand)
+    duplicateOperand = findFirstDuplicateInput(classOp);
+  if (!duplicateOperand)
+    return;
+
+  emitted = true;
+  llvm::dbgs() << "FIRST duplicate ClassOp detected at " << label << "\n";
+  llvm::dbgs() << "  class: ";
+  classOp.dump();
+  llvm::dbgs() << "  duplicate operand: ";
+  duplicateOperand.dump();
+  llvm::dbgs() << "  class input count: " << classOp.getInputs().size() << "\n";
+}
+
+void logDuplicateClassOpState(llvm::StringRef label,
+                              equivalence::ClassOp classOp,
+                              Value duplicateOperand = {}) {
+  if (classInputsAreUnique(classOp))
+    return;
+
+  if (!duplicateOperand)
+    duplicateOperand = findFirstDuplicateInput(classOp);
+
+  llvm::dbgs() << label << ": ";
+  classOp.dump();
+  llvm::dbgs() << "    inputs[" << classOp.getInputs().size() << "]: ";
+
+  SmallPtrSet<Value, 8> seen;
+  bool first = true;
+  for (Value operand : classOp.getInputs()) {
+    if (!first)
+      llvm::dbgs() << ", ";
+    first = false;
+
+    if (!seen.insert(operand).second)
+      llvm::dbgs() << "<dup> ";
+    llvm::dbgs() << operand;
+  }
+
+  llvm::dbgs() << "\n";
+  if (duplicateOperand) {
+    llvm::dbgs() << "    first duplicate operand: ";
+    duplicateOperand.dump();
+  }
+  llvm::dbgs() << "    WARNING: duplicate inputs detected in this ClassOp\n";
+}
+
+void logDuplicateLookupContext(llvm::StringRef label, Value queryValue,
+                               equivalence::ClassOp classOp,
+                               Value duplicateOperand = {}) {
+  if (!duplicateOperand)
+    duplicateOperand = findFirstDuplicateInput(classOp);
+  if (!duplicateOperand)
+    return;
+
+  logFirstDuplicateOnly(label, classOp, duplicateOperand);
+  llvm::dbgs() << label << "\n";
+  llvm::dbgs() << "  query value: ";
+  queryValue.dump();
+  logDuplicateClassOpState("  returned class is duplicate", classOp,
+                           duplicateOperand);
+}
+
+unsigned countDistinctClassUsers(
+    Value value, SmallVectorImpl<equivalence::ClassOp> *users = nullptr) {
+  SmallPtrSet<Operation *, 8> seen;
+  unsigned count = 0;
+  for (OpOperand &use : value.getUses()) {
+    if (auto classOp = dyn_cast<equivalence::ClassOp>(*use.getOwner())) {
+      // Leader-pointer uses are expected during union/rebuild and do not mean
+      // the value is a member candidate of multiple classes.
+      bool isInputUse = llvm::is_contained(classOp.getInputs(), value);
+      if (!isInputUse)
+        continue;
+
+      if (seen.insert(classOp.getOperation()).second) {
+        ++count;
+        if (users)
+          users->push_back(classOp);
+      }
+    }
+  }
+  return count;
+}
+
+unsigned countDistinctCanonicalClassLeaders(Value value) {
+  SmallPtrSet<Operation *, 8> seen;
+  for (OpOperand &use : value.getUses()) {
+    if (auto classOp = dyn_cast<equivalence::ClassOp>(*use.getOwner())) {
+      bool isInputUse = llvm::is_contained(classOp.getInputs(), value);
+      if (!isInputUse || !classOp->getBlock())
+        continue;
+
+      equivalence::ClassOp leader = getCanonicalLeader(classOp);
+      if (!leader || !leader->getBlock())
+        continue;
+      seen.insert(leader.getOperation());
+    }
+  }
+  return seen.size();
+}
+
+void logFirstClassUserFanoutTransition(llvm::StringRef label, Value value,
+                                       unsigned beforeCount) {
+  SmallVector<equivalence::ClassOp, 4> users;
+  unsigned afterCount = countDistinctClassUsers(value, &users);
+  if (!(beforeCount <= 1 && afterCount > 1))
+    return;
+
+  // During repair/rebuild, a value can briefly appear in multiple classes that
+  // are already in the same union-find component. Only report persistent
+  // fanout across different canonical leaders.
+  unsigned canonicalLeaderCount = countDistinctCanonicalClassLeaders(value);
+  if (canonicalLeaderCount <= 1)
+    return;
+
+  static bool emitted = false;
+  if (emitted)
+    return;
+  emitted = true;
+
+  llvm::dbgs() << "FIRST value fanout to multiple ClassOps at " << label
+               << " (before=" << beforeCount << ", after=" << afterCount
+               << ", canonical_leaders=" << canonicalLeaderCount << ")\n";
+  llvm::dbgs() << "  value: ";
+  value.dump();
+  for (equivalence::ClassOp classUser : users) {
+    llvm::dbgs() << "  class user: ";
+    classUser.dump();
+  }
+}
+
+} // namespace
+
 SmallVector<Value> mlir::ematch::getClassVals(PatternRewriter &rewriter,
                                               Value val) {
   Operation *defOp = val.getDefiningOp();
   if (defOp == nullptr) {
     return {val};
   } else if (auto classOp = dyn_cast<equivalence::ClassOp>(defOp)) {
+    LLVM_DEBUG({
+      Value dupOperand = findFirstDuplicateInput(classOp);
+      if (dupOperand) {
+        logFirstDuplicateOnly("getClassVals: class operand has duplicates",
+                              classOp, dupOperand);
+        logDuplicateClassOpState("getClassVals: class operand has duplicates",
+                                 classOp, dupOperand);
+      }
+    });
     return llvm::to_vector(classOp->getOperands());
   }
   return {val};
@@ -46,6 +215,21 @@ SmallVector<Value> mlir::ematch::getClassVals(PatternRewriter &rewriter,
 
 Value mlir::ematch::getClassRepresentative(PatternRewriter &rewriter,
                                            Value val) {
+  if (auto *defOp = val.getDefiningOp()) {
+    if (auto classOp = dyn_cast<equivalence::ClassOp>(*defOp)) {
+      LLVM_DEBUG({
+        Value dupOperand = findFirstDuplicateInput(classOp);
+        if (dupOperand) {
+          logFirstDuplicateOnly(
+              "getClassRepresentative: source class has duplicates", classOp,
+              dupOperand);
+          logDuplicateClassOpState(
+              "getClassRepresentative: source class has duplicates", classOp,
+              dupOperand);
+        }
+      });
+    }
+  }
   return getClassVals(rewriter, val)[0];
 }
 
@@ -74,6 +258,16 @@ Value mlir::ematch::getClassResult(PatternRewriter &rewriter, Value val) {
   if (auto classOp = val.hasOneUse()
                          ? dyn_cast<equivalence::ClassOp>(*val.user_begin())
                          : nullptr) {
+    LLVM_DEBUG({
+      Value dupOperand = findFirstDuplicateInput(classOp);
+      if (dupOperand) {
+        logFirstDuplicateOnly("getClassResult: returned class has duplicates",
+                              classOp, dupOperand);
+        logDuplicateClassOpState(
+            "getClassResult: returned class has duplicates", classOp,
+            dupOperand);
+      }
+    });
     return classOp.getResult();
   }
   return val;
@@ -93,12 +287,44 @@ SmallVector<Value> mlir::ematch::getClassResults(PatternRewriter &rewriter,
 
 equivalence::ClassOp getClassOpIfExists(Value val) {
   if (auto *defOp = val.getDefiningOp()) {
-    if (auto classOp = dyn_cast<equivalence::ClassOp>(*defOp))
+    if (auto classOp = dyn_cast<equivalence::ClassOp>(*defOp)) {
+      LLVM_DEBUG({
+        Value dupOperand = findFirstDuplicateInput(classOp);
+        if (dupOperand) {
+          logDuplicateLookupContext("getClassOpIfExists(defOp): duplicate", val,
+                                    classOp, dupOperand);
+        }
+      });
       return classOp;
+    }
   }
+
+  unsigned classUserCount = 0;
+  equivalence::ClassOp firstClassUser = nullptr;
   for (Operation *user : val.getUsers()) {
-    if (auto classOp = dyn_cast<equivalence::ClassOp>(*user))
-      return classOp;
+    if (auto classOp = dyn_cast<equivalence::ClassOp>(*user)) {
+      if (!firstClassUser)
+        firstClassUser = classOp;
+      ++classUserCount;
+    }
+  }
+
+  if (firstClassUser) {
+    LLVM_DEBUG({
+      if (classUserCount > 1) {
+        llvm::dbgs() << "getClassOpIfExists(user): value has " << classUserCount
+                     << " ClassOp users\n";
+        llvm::dbgs() << "  query value: ";
+        val.dump();
+      }
+
+      Value dupOperand = findFirstDuplicateInput(firstClassUser);
+      if (dupOperand) {
+        logDuplicateLookupContext("getClassOpIfExists(user): duplicate", val,
+                                  firstClassUser, dupOperand);
+      }
+    });
+    return firstClassUser;
   }
   return nullptr;
 }
@@ -117,9 +343,14 @@ equivalence::ClassOp mlir::ematch::getClassOp(PatternRewriter &rewriter,
   auto classOp = equivalence::ClassOp::create(
       builder, val.getLoc(), TypeRange{val.getType()}, ValueRange{val},
       /*leader=*/Value{}, /*min_cost_index=*/nullptr);
+  unsigned beforeClassUsers = countDistinctClassUsers(classOp.getResult());
   rewriter.replaceUsesWithIf(
       val, classOp.getResult(),
       [&classOp](OpOperand &operand) { return operand.getOwner() != classOp; });
+  LLVM_DEBUG({
+    logFirstClassUserFanoutTransition("getClassOp: replaceUsesWithIf",
+                                      classOp.getResult(), beforeClassUsers);
+  });
   return classOp;
 }
 
@@ -137,11 +368,60 @@ void ClassOpUnionFind::classUnion(PatternRewriter &rewriter, Value a, Value b) {
   equivalence::ClassOp leader = getCanonicalLeader(classA);
   equivalence::ClassOp other = getCanonicalLeader(classB);
 
+  LLVM_DEBUG({
+    Value classADup = findFirstDuplicateInput(classA);
+    if (classADup) {
+      logFirstDuplicateOnly("classUnion: classA already has duplicates", classA,
+                            classADup);
+      llvm::dbgs() << "classUnion duplicate context (classA)\n";
+      llvm::dbgs() << "  union lhs arg: ";
+      a.dump();
+      llvm::dbgs() << "  union rhs arg: ";
+      b.dump();
+      logDuplicateClassOpState("classUnion: classA already has duplicates",
+                               classA, classADup);
+    }
+
+    Value classBDup = findFirstDuplicateInput(classB);
+    if (classBDup) {
+      logFirstDuplicateOnly("classUnion: classB already has duplicates", classB,
+                            classBDup);
+      llvm::dbgs() << "classUnion duplicate context (classB)\n";
+      llvm::dbgs() << "  union lhs arg: ";
+      a.dump();
+      llvm::dbgs() << "  union rhs arg: ";
+      b.dump();
+      logDuplicateClassOpState("classUnion: classB already has duplicates",
+                               classB, classBDup);
+    }
+
+    Value leaderDup = findFirstDuplicateInput(leader);
+    if (leaderDup) {
+      logFirstDuplicateOnly("classUnion: leader already has duplicates", leader,
+                            leaderDup);
+      logDuplicateClassOpState("classUnion: leader already has duplicates",
+                               leader, leaderDup);
+    }
+
+    Value otherDup = findFirstDuplicateInput(other);
+    if (otherDup) {
+      logFirstDuplicateOnly("classUnion: other already has duplicates", other,
+                            otherDup);
+      logDuplicateClassOpState("classUnion: other already has duplicates",
+                               other, otherDup);
+    }
+  });
+
   if (leader == other)
     return;
 
   // Lazy union: just point `other` at `leader` via the leader operand.
+  unsigned beforeLeaderUsers = countDistinctClassUsers(leader.getResult());
   other.getLeaderMutable().assign(leader.getResult());
+  LLVM_DEBUG({
+    logFirstClassUserFanoutTransition("classUnion: assign leader",
+                                      leader.getResult(), beforeLeaderUsers);
+  });
 
   // We push `other` such that at the start of `rebuild`,
   worklist.push_back(other);
@@ -181,12 +461,12 @@ void ClassOpUnionFind::queueClassUnion(ValueRange a, ValueRange b) {
 
 void ClassOpUnionFind::processPendingClassUnions(PatternRewriter &rewriter) {
   for (auto [a, b] : pendingClassUnions) {
-    LLVM_DEBUG({
-      llvm::dbgs() << "Unioning:\n\t";
-      a.dump();
-      llvm::dbgs() << "\t";
-      b.dump();
-    });
+    // LLVM_DEBUG({
+    //   llvm::dbgs() << "Unioning:\n\t";
+    //   a.dump();
+    //   llvm::dbgs() << "\t";
+    //   b.dump();
+    // });
     classUnion(rewriter, a, b);
   }
   pendingClassUnions.clear();
@@ -194,15 +474,15 @@ void ClassOpUnionFind::processPendingClassUnions(PatternRewriter &rewriter) {
 
 bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
   TAMAGOYAKI_SCOPED_TIMER("rebuild");
-  LLVM_DEBUG({
-    llvm::dbgs() << "Starting rebuild. Worklist contains " << worklist.size()
-                 << " classes\n";
-    llvm::dbgs() << "Worklist: ";
-    for (auto rep : worklist) {
-      llvm::dbgs() << "\t";
-      rep.dump();
-    }
-  });
+  // LLVM_DEBUG({
+  //   llvm::dbgs() << "Starting rebuild. Worklist contains " << worklist.size()
+  //                << " classes\n";
+  //   llvm::dbgs() << "Worklist: ";
+  //   for (auto rep : worklist) {
+  //     llvm::dbgs() << "\t";
+  //     rep.dump();
+  //   }
+  // });
 
   if (worklist.empty())
     return false;
@@ -216,19 +496,43 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
 
       auto leader = getCanonicalLeader(c);
       if (c != leader) { // c needs to be canonicalized
+        bool leaderWasUnique = classInputsAreUnique(leader);
+
         // add operands to leader (deduplicated)
         SmallPtrSet<Value, 8> existing(leader.getInputs().begin(),
                                        leader.getInputs().end());
         SmallVector<Value, 8> newOperands;
+        SmallVector<std::pair<Value, unsigned>, 8> beforeCounts;
         for (Value operand : c.getInputs()) {
           assert(
               !operand.getDefiningOp() ||
               !llvm::dyn_cast<equivalence::ClassOp>(operand.getDefiningOp()));
-          if (existing.insert(operand).second)
+          if (existing.insert(operand).second) {
             newOperands.push_back(operand);
+            beforeCounts.emplace_back(operand,
+                                      countDistinctClassUsers(operand));
+          }
         }
         auto mutableInputs = leader.getInputsMutable();
         mutableInputs.append(newOperands);
+
+        LLVM_DEBUG({
+          Value dupOperand = findFirstDuplicateInput(leader);
+          if (dupOperand) {
+            if (leaderWasUnique) {
+              logFirstDuplicateOnly("rebuild: became-duplicate-after-append",
+                                    leader, dupOperand);
+              logDuplicateClassOpState("rebuild: became-duplicate-after-append",
+                                       leader, dupOperand);
+            } else {
+              logFirstDuplicateOnly("rebuild: already-duplicate-before-append",
+                                    leader, dupOperand);
+              logDuplicateClassOpState(
+                  "rebuild: already-duplicate-before-append", leader,
+                  dupOperand);
+            }
+          }
+        });
 
         // update all users of c
         rewriter.replaceAllUsesWith(c.getResult(), leader.getResult());
@@ -238,6 +542,13 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
         c.getLeaderMutable().clear();
         c->remove();
         pendingErase.push_back(c);
+
+        LLVM_DEBUG({
+          for (auto [operand, before] : beforeCounts) {
+            logFirstClassUserFanoutTransition(
+                "rebuild: post-canonicalization cleanup", operand, before);
+          }
+        });
       }
       todo.insert(leader);
     }
@@ -252,13 +563,13 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
 
   // Now that the worklist is fully drained, erase all dead eclasses that
   // were deferred during classUnion.
-  LLVM_DEBUG({
-    llvm::dbgs() << "Pending erases:\n";
-    for (equivalence::ClassOp dead : pendingErase) {
-      llvm::dbgs() << "\t";
-      dead.dump();
-    }
-  });
+  // LLVM_DEBUG({
+  //   llvm::dbgs() << "Pending erases:\n";
+  //   for (equivalence::ClassOp dead : pendingErase) {
+  //     llvm::dbgs() << "\t";
+  //     dead.dump();
+  //   }
+  // });
   SmallPtrSet<Operation *, 8> erased;
   for (equivalence::ClassOp dead : pendingErase) {
     if (erased.insert(dead.getOperation()).second)
@@ -274,6 +585,15 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
   if (classOp->getBlock() == nullptr) {
     return;
   }
+
+  LLVM_DEBUG({
+    Value dupOperand = findFirstDuplicateInput(classOp);
+    if (dupOperand) {
+      logFirstDuplicateOnly("repair: entry", classOp, dupOperand);
+      logDuplicateClassOpState("repair: entry already violates uniqueness",
+                               classOp, dupOperand);
+    }
+  });
 
   llvm::DenseMap<Operation *, Operation *, SimpleOperationInfo> uniqueParents;
   // Collect pairs of duplicate operations to merge AFTER the loop
@@ -315,7 +635,12 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
       if (classKeep && classOther) {
         // Case 1: both values have a class — replace other's results with
         // keep's results, then union the two classes.
+        unsigned beforeResKeepUsers = countDistinctClassUsers(resKeep);
         rewriter.replaceAllUsesWith(resOther, resKeep);
+        LLVM_DEBUG({
+          logFirstClassUserFanoutTransition("repair/case1: replaceAllUsesWith",
+                                            resKeep, beforeResKeepUsers);
+        });
         // The replaceAllUsesWith above rewrote resOther -> resKeep inside
         // classOther's input list.  That means resKeep is now an input of
         // *both* classKeep and classOther, breaking the single-class-
@@ -330,6 +655,7 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
           }
           if (filtered.size() != otherInputs.size())
             otherInputs.assign(filtered);
+
           classUnion(rewriter, classKeep.getResult(), classOther.getResult());
         } else {
           SmallPtrSet<Value, 8> seen;
@@ -339,23 +665,52 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
               uniqueOperands.push_back(operand);
           }
           classKeep.getInputsMutable().assign(uniqueOperands);
+          LLVM_DEBUG({
+            logDuplicateClassOpState("repair: duplicate remains after dedupe",
+                                     classKeep);
+          });
         }
       } else if (classKeep) {
         // Case 2: only keep has a class — redirect other's results to the
         // class representative rather than the raw result.
+        unsigned beforeClassKeepUsers =
+            countDistinctClassUsers(classKeep.getResult());
         rewriter.replaceAllUsesWith(resOther, classKeep.getResult());
+        LLVM_DEBUG({
+          logFirstClassUserFanoutTransition("repair/case2: replaceAllUsesWith",
+                                            classKeep.getResult(),
+                                            beforeClassKeepUsers);
+        });
       } else if (classOther) {
         // Case 3: only other has a class — redirect keep's non-ClassOp users
         // through classOther first, then retarget classOther from resOther to
         // resKeep.
+        unsigned beforeClassOtherUsers =
+            countDistinctClassUsers(classOther.getResult());
         rewriter.replaceUsesWithIf(resKeep, classOther.getResult(),
                                    [&](OpOperand &operand) {
                                      return operand.getOwner() != classOther;
                                    });
+        LLVM_DEBUG({
+          logFirstClassUserFanoutTransition("repair/case3: replaceUsesWithIf",
+                                            classOther.getResult(),
+                                            beforeClassOtherUsers);
+        });
+        unsigned beforeResKeepUsers = countDistinctClassUsers(resKeep);
         rewriter.replaceAllUsesWith(resOther, resKeep);
+        LLVM_DEBUG({
+          logFirstClassUserFanoutTransition(
+              "repair/case3: replaceAllUsesWith(resOther,resKeep)", resKeep,
+              beforeResKeepUsers);
+        });
       } else {
         // Case 4: neither has a class — simple replacement.
+        unsigned beforeResKeepUsers = countDistinctClassUsers(resKeep);
         rewriter.replaceAllUsesWith(resOther, resKeep);
+        LLVM_DEBUG({
+          logFirstClassUserFanoutTransition("repair/case4: replaceAllUsesWith",
+                                            resKeep, beforeResKeepUsers);
+        });
       }
     }
     rewriter.eraseOp(other);

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -358,6 +358,9 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
         rewriter.replaceAllUsesWith(resOther, resKeep);
       }
     }
-    rewriter.eraseOp(other);
+    // Don't just erase the op, instead, replace. Listeners such as the
+    // OriginalOpTracker used in herbie-mlir should be able to tell what
+    // `other` is replaced with:
+    rewriter.replaceOp(other, keep);
   }
 }

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -316,7 +316,20 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
         // Case 1: both values have a class — replace other's results with
         // keep's results, then union the two classes.
         rewriter.replaceAllUsesWith(resOther, resKeep);
+        // The replaceAllUsesWith above rewrote resOther -> resKeep inside
+        // classOther's input list.  That means resKeep is now an input of
+        // *both* classKeep and classOther, breaking the single-class-
+        // membership invariant.  Remove the stale occurrence from
+        // classOther so that resKeep only belongs to classKeep.
         if (classKeep != classOther) {
+          auto otherInputs = classOther.getInputsMutable();
+          SmallVector<Value> filtered;
+          for (Value v : classOther.getInputs()) {
+            if (v != resKeep)
+              filtered.push_back(v);
+          }
+          if (filtered.size() != otherInputs.size())
+            otherInputs.assign(filtered);
           classUnion(rewriter, classKeep.getResult(), classOther.getResult());
         } else {
           SmallPtrSet<Value, 8> seen;

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -331,9 +331,17 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
         // Case 2: only keep has a class — redirect other's results to the
         // class representative rather than the raw result.
         rewriter.replaceAllUsesWith(resOther, classKeep.getResult());
+      } else if (classOther) {
+        // Case 3: only other has a class — redirect keep's non-ClassOp users
+        // through classOther first, then retarget classOther from resOther to
+        // resKeep.
+        rewriter.replaceUsesWithIf(resKeep, classOther.getResult(),
+                                   [&](OpOperand &operand) {
+                                     return operand.getOwner() != classOther;
+                                   });
+        rewriter.replaceAllUsesWith(resOther, resKeep);
       } else {
-        // Case 3 (only other has a class) & Case 4 (neither has a class):
-        // replace other's results with keep's results.
+        // Case 4: neither has a class — simple replacement.
         rewriter.replaceAllUsesWith(resOther, resKeep);
       }
     }

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -33,181 +33,12 @@
 using namespace mlir;
 using namespace mlir::ematch;
 
-namespace {
-
-bool classInputsAreUnique(equivalence::ClassOp classOp) {
-  SmallPtrSet<Value, 8> seen;
-  for (Value operand : classOp.getInputs()) {
-    if (!seen.insert(operand).second)
-      return false;
-  }
-  return true;
-}
-
-Value findFirstDuplicateInput(equivalence::ClassOp classOp) {
-  SmallPtrSet<Value, 8> seen;
-  for (Value operand : classOp.getInputs()) {
-    if (!seen.insert(operand).second)
-      return operand;
-  }
-  return {};
-}
-
-void logFirstDuplicateOnly(llvm::StringRef label, equivalence::ClassOp classOp,
-                           Value duplicateOperand = {}) {
-  static bool emitted = false;
-  if (emitted)
-    return;
-
-  if (!duplicateOperand)
-    duplicateOperand = findFirstDuplicateInput(classOp);
-  if (!duplicateOperand)
-    return;
-
-  emitted = true;
-  llvm::dbgs() << "FIRST duplicate ClassOp detected at " << label << "\n";
-  llvm::dbgs() << "  class: ";
-  classOp.dump();
-  llvm::dbgs() << "  duplicate operand: ";
-  duplicateOperand.dump();
-  llvm::dbgs() << "  class input count: " << classOp.getInputs().size() << "\n";
-}
-
-void logDuplicateClassOpState(llvm::StringRef label,
-                              equivalence::ClassOp classOp,
-                              Value duplicateOperand = {}) {
-  if (classInputsAreUnique(classOp))
-    return;
-
-  if (!duplicateOperand)
-    duplicateOperand = findFirstDuplicateInput(classOp);
-
-  llvm::dbgs() << label << ": ";
-  classOp.dump();
-  llvm::dbgs() << "    inputs[" << classOp.getInputs().size() << "]: ";
-
-  SmallPtrSet<Value, 8> seen;
-  bool first = true;
-  for (Value operand : classOp.getInputs()) {
-    if (!first)
-      llvm::dbgs() << ", ";
-    first = false;
-
-    if (!seen.insert(operand).second)
-      llvm::dbgs() << "<dup> ";
-    llvm::dbgs() << operand;
-  }
-
-  llvm::dbgs() << "\n";
-  if (duplicateOperand) {
-    llvm::dbgs() << "    first duplicate operand: ";
-    duplicateOperand.dump();
-  }
-  llvm::dbgs() << "    WARNING: duplicate inputs detected in this ClassOp\n";
-}
-
-void logDuplicateLookupContext(llvm::StringRef label, Value queryValue,
-                               equivalence::ClassOp classOp,
-                               Value duplicateOperand = {}) {
-  if (!duplicateOperand)
-    duplicateOperand = findFirstDuplicateInput(classOp);
-  if (!duplicateOperand)
-    return;
-
-  logFirstDuplicateOnly(label, classOp, duplicateOperand);
-  llvm::dbgs() << label << "\n";
-  llvm::dbgs() << "  query value: ";
-  queryValue.dump();
-  logDuplicateClassOpState("  returned class is duplicate", classOp,
-                           duplicateOperand);
-}
-
-unsigned countDistinctClassUsers(
-    Value value, SmallVectorImpl<equivalence::ClassOp> *users = nullptr) {
-  SmallPtrSet<Operation *, 8> seen;
-  unsigned count = 0;
-  for (OpOperand &use : value.getUses()) {
-    if (auto classOp = dyn_cast<equivalence::ClassOp>(*use.getOwner())) {
-      // Leader-pointer uses are expected during union/rebuild and do not mean
-      // the value is a member candidate of multiple classes.
-      bool isInputUse = llvm::is_contained(classOp.getInputs(), value);
-      if (!isInputUse)
-        continue;
-
-      if (seen.insert(classOp.getOperation()).second) {
-        ++count;
-        if (users)
-          users->push_back(classOp);
-      }
-    }
-  }
-  return count;
-}
-
-unsigned countDistinctCanonicalClassLeaders(Value value) {
-  SmallPtrSet<Operation *, 8> seen;
-  for (OpOperand &use : value.getUses()) {
-    if (auto classOp = dyn_cast<equivalence::ClassOp>(*use.getOwner())) {
-      bool isInputUse = llvm::is_contained(classOp.getInputs(), value);
-      if (!isInputUse || !classOp->getBlock())
-        continue;
-
-      equivalence::ClassOp leader = getCanonicalLeader(classOp);
-      if (!leader || !leader->getBlock())
-        continue;
-      seen.insert(leader.getOperation());
-    }
-  }
-  return seen.size();
-}
-
-void logFirstClassUserFanoutTransition(llvm::StringRef label, Value value,
-                                       unsigned beforeCount) {
-  SmallVector<equivalence::ClassOp, 4> users;
-  unsigned afterCount = countDistinctClassUsers(value, &users);
-  if (!(beforeCount <= 1 && afterCount > 1))
-    return;
-
-  // During repair/rebuild, a value can briefly appear in multiple classes that
-  // are already in the same union-find component. Only report persistent
-  // fanout across different canonical leaders.
-  unsigned canonicalLeaderCount = countDistinctCanonicalClassLeaders(value);
-  if (canonicalLeaderCount <= 1)
-    return;
-
-  static bool emitted = false;
-  if (emitted)
-    return;
-  emitted = true;
-
-  llvm::dbgs() << "FIRST value fanout to multiple ClassOps at " << label
-               << " (before=" << beforeCount << ", after=" << afterCount
-               << ", canonical_leaders=" << canonicalLeaderCount << ")\n";
-  llvm::dbgs() << "  value: ";
-  value.dump();
-  for (equivalence::ClassOp classUser : users) {
-    llvm::dbgs() << "  class user: ";
-    classUser.dump();
-  }
-}
-
-} // namespace
-
 SmallVector<Value> mlir::ematch::getClassVals(PatternRewriter &rewriter,
                                               Value val) {
   Operation *defOp = val.getDefiningOp();
   if (defOp == nullptr) {
     return {val};
   } else if (auto classOp = dyn_cast<equivalence::ClassOp>(defOp)) {
-    LLVM_DEBUG({
-      Value dupOperand = findFirstDuplicateInput(classOp);
-      if (dupOperand) {
-        logFirstDuplicateOnly("getClassVals: class operand has duplicates",
-                              classOp, dupOperand);
-        logDuplicateClassOpState("getClassVals: class operand has duplicates",
-                                 classOp, dupOperand);
-      }
-    });
     return llvm::to_vector(classOp->getOperands());
   }
   return {val};
@@ -215,21 +46,6 @@ SmallVector<Value> mlir::ematch::getClassVals(PatternRewriter &rewriter,
 
 Value mlir::ematch::getClassRepresentative(PatternRewriter &rewriter,
                                            Value val) {
-  if (auto *defOp = val.getDefiningOp()) {
-    if (auto classOp = dyn_cast<equivalence::ClassOp>(*defOp)) {
-      LLVM_DEBUG({
-        Value dupOperand = findFirstDuplicateInput(classOp);
-        if (dupOperand) {
-          logFirstDuplicateOnly(
-              "getClassRepresentative: source class has duplicates", classOp,
-              dupOperand);
-          logDuplicateClassOpState(
-              "getClassRepresentative: source class has duplicates", classOp,
-              dupOperand);
-        }
-      });
-    }
-  }
   return getClassVals(rewriter, val)[0];
 }
 
@@ -258,16 +74,6 @@ Value mlir::ematch::getClassResult(PatternRewriter &rewriter, Value val) {
   if (auto classOp = val.hasOneUse()
                          ? dyn_cast<equivalence::ClassOp>(*val.user_begin())
                          : nullptr) {
-    LLVM_DEBUG({
-      Value dupOperand = findFirstDuplicateInput(classOp);
-      if (dupOperand) {
-        logFirstDuplicateOnly("getClassResult: returned class has duplicates",
-                              classOp, dupOperand);
-        logDuplicateClassOpState(
-            "getClassResult: returned class has duplicates", classOp,
-            dupOperand);
-      }
-    });
     return classOp.getResult();
   }
   return val;
@@ -287,44 +93,12 @@ SmallVector<Value> mlir::ematch::getClassResults(PatternRewriter &rewriter,
 
 equivalence::ClassOp getClassOpIfExists(Value val) {
   if (auto *defOp = val.getDefiningOp()) {
-    if (auto classOp = dyn_cast<equivalence::ClassOp>(*defOp)) {
-      LLVM_DEBUG({
-        Value dupOperand = findFirstDuplicateInput(classOp);
-        if (dupOperand) {
-          logDuplicateLookupContext("getClassOpIfExists(defOp): duplicate", val,
-                                    classOp, dupOperand);
-        }
-      });
+    if (auto classOp = dyn_cast<equivalence::ClassOp>(*defOp))
       return classOp;
-    }
   }
-
-  unsigned classUserCount = 0;
-  equivalence::ClassOp firstClassUser = nullptr;
   for (Operation *user : val.getUsers()) {
-    if (auto classOp = dyn_cast<equivalence::ClassOp>(*user)) {
-      if (!firstClassUser)
-        firstClassUser = classOp;
-      ++classUserCount;
-    }
-  }
-
-  if (firstClassUser) {
-    LLVM_DEBUG({
-      if (classUserCount > 1) {
-        llvm::dbgs() << "getClassOpIfExists(user): value has " << classUserCount
-                     << " ClassOp users\n";
-        llvm::dbgs() << "  query value: ";
-        val.dump();
-      }
-
-      Value dupOperand = findFirstDuplicateInput(firstClassUser);
-      if (dupOperand) {
-        logDuplicateLookupContext("getClassOpIfExists(user): duplicate", val,
-                                  firstClassUser, dupOperand);
-      }
-    });
-    return firstClassUser;
+    if (auto classOp = dyn_cast<equivalence::ClassOp>(*user))
+      return classOp;
   }
   return nullptr;
 }
@@ -343,14 +117,9 @@ equivalence::ClassOp mlir::ematch::getClassOp(PatternRewriter &rewriter,
   auto classOp = equivalence::ClassOp::create(
       builder, val.getLoc(), TypeRange{val.getType()}, ValueRange{val},
       /*leader=*/Value{}, /*min_cost_index=*/nullptr);
-  unsigned beforeClassUsers = countDistinctClassUsers(classOp.getResult());
   rewriter.replaceUsesWithIf(
       val, classOp.getResult(),
       [&classOp](OpOperand &operand) { return operand.getOwner() != classOp; });
-  LLVM_DEBUG({
-    logFirstClassUserFanoutTransition("getClassOp: replaceUsesWithIf",
-                                      classOp.getResult(), beforeClassUsers);
-  });
   return classOp;
 }
 
@@ -368,60 +137,11 @@ void ClassOpUnionFind::classUnion(PatternRewriter &rewriter, Value a, Value b) {
   equivalence::ClassOp leader = getCanonicalLeader(classA);
   equivalence::ClassOp other = getCanonicalLeader(classB);
 
-  LLVM_DEBUG({
-    Value classADup = findFirstDuplicateInput(classA);
-    if (classADup) {
-      logFirstDuplicateOnly("classUnion: classA already has duplicates", classA,
-                            classADup);
-      llvm::dbgs() << "classUnion duplicate context (classA)\n";
-      llvm::dbgs() << "  union lhs arg: ";
-      a.dump();
-      llvm::dbgs() << "  union rhs arg: ";
-      b.dump();
-      logDuplicateClassOpState("classUnion: classA already has duplicates",
-                               classA, classADup);
-    }
-
-    Value classBDup = findFirstDuplicateInput(classB);
-    if (classBDup) {
-      logFirstDuplicateOnly("classUnion: classB already has duplicates", classB,
-                            classBDup);
-      llvm::dbgs() << "classUnion duplicate context (classB)\n";
-      llvm::dbgs() << "  union lhs arg: ";
-      a.dump();
-      llvm::dbgs() << "  union rhs arg: ";
-      b.dump();
-      logDuplicateClassOpState("classUnion: classB already has duplicates",
-                               classB, classBDup);
-    }
-
-    Value leaderDup = findFirstDuplicateInput(leader);
-    if (leaderDup) {
-      logFirstDuplicateOnly("classUnion: leader already has duplicates", leader,
-                            leaderDup);
-      logDuplicateClassOpState("classUnion: leader already has duplicates",
-                               leader, leaderDup);
-    }
-
-    Value otherDup = findFirstDuplicateInput(other);
-    if (otherDup) {
-      logFirstDuplicateOnly("classUnion: other already has duplicates", other,
-                            otherDup);
-      logDuplicateClassOpState("classUnion: other already has duplicates",
-                               other, otherDup);
-    }
-  });
-
   if (leader == other)
     return;
 
   // Lazy union: just point `other` at `leader` via the leader operand.
-  unsigned beforeLeaderUsers = countDistinctClassUsers(leader.getResult());
   other.getLeaderMutable().assign(leader.getResult());
-  LLVM_DEBUG({
-    logFirstClassUserFanoutTransition("classUnion: assign leader",
-                                      leader.getResult(), beforeLeaderUsers);
-  });
 
   // We push `other` such that at the start of `rebuild`,
   worklist.push_back(other);
@@ -461,12 +181,12 @@ void ClassOpUnionFind::queueClassUnion(ValueRange a, ValueRange b) {
 
 void ClassOpUnionFind::processPendingClassUnions(PatternRewriter &rewriter) {
   for (auto [a, b] : pendingClassUnions) {
-    // LLVM_DEBUG({
-    //   llvm::dbgs() << "Unioning:\n\t";
-    //   a.dump();
-    //   llvm::dbgs() << "\t";
-    //   b.dump();
-    // });
+    LLVM_DEBUG({
+      llvm::dbgs() << "Unioning:\n\t";
+      a.dump();
+      llvm::dbgs() << "\t";
+      b.dump();
+    });
     classUnion(rewriter, a, b);
   }
   pendingClassUnions.clear();
@@ -474,15 +194,15 @@ void ClassOpUnionFind::processPendingClassUnions(PatternRewriter &rewriter) {
 
 bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
   TAMAGOYAKI_SCOPED_TIMER("rebuild");
-  // LLVM_DEBUG({
-  //   llvm::dbgs() << "Starting rebuild. Worklist contains " << worklist.size()
-  //                << " classes\n";
-  //   llvm::dbgs() << "Worklist: ";
-  //   for (auto rep : worklist) {
-  //     llvm::dbgs() << "\t";
-  //     rep.dump();
-  //   }
-  // });
+  LLVM_DEBUG({
+    llvm::dbgs() << "Starting rebuild. Worklist contains " << worklist.size()
+                 << " classes\n";
+    llvm::dbgs() << "Worklist: ";
+    for (auto rep : worklist) {
+      llvm::dbgs() << "\t";
+      rep.dump();
+    }
+  });
 
   if (worklist.empty())
     return false;
@@ -496,43 +216,19 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
 
       auto leader = getCanonicalLeader(c);
       if (c != leader) { // c needs to be canonicalized
-        bool leaderWasUnique = classInputsAreUnique(leader);
-
         // add operands to leader (deduplicated)
         SmallPtrSet<Value, 8> existing(leader.getInputs().begin(),
                                        leader.getInputs().end());
         SmallVector<Value, 8> newOperands;
-        SmallVector<std::pair<Value, unsigned>, 8> beforeCounts;
         for (Value operand : c.getInputs()) {
           assert(
               !operand.getDefiningOp() ||
               !llvm::dyn_cast<equivalence::ClassOp>(operand.getDefiningOp()));
-          if (existing.insert(operand).second) {
+          if (existing.insert(operand).second)
             newOperands.push_back(operand);
-            beforeCounts.emplace_back(operand,
-                                      countDistinctClassUsers(operand));
-          }
         }
         auto mutableInputs = leader.getInputsMutable();
         mutableInputs.append(newOperands);
-
-        LLVM_DEBUG({
-          Value dupOperand = findFirstDuplicateInput(leader);
-          if (dupOperand) {
-            if (leaderWasUnique) {
-              logFirstDuplicateOnly("rebuild: became-duplicate-after-append",
-                                    leader, dupOperand);
-              logDuplicateClassOpState("rebuild: became-duplicate-after-append",
-                                       leader, dupOperand);
-            } else {
-              logFirstDuplicateOnly("rebuild: already-duplicate-before-append",
-                                    leader, dupOperand);
-              logDuplicateClassOpState(
-                  "rebuild: already-duplicate-before-append", leader,
-                  dupOperand);
-            }
-          }
-        });
 
         // update all users of c
         rewriter.replaceAllUsesWith(c.getResult(), leader.getResult());
@@ -542,13 +238,6 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
         c.getLeaderMutable().clear();
         c->remove();
         pendingErase.push_back(c);
-
-        LLVM_DEBUG({
-          for (auto [operand, before] : beforeCounts) {
-            logFirstClassUserFanoutTransition(
-                "rebuild: post-canonicalization cleanup", operand, before);
-          }
-        });
       }
       todo.insert(leader);
     }
@@ -563,13 +252,13 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
 
   // Now that the worklist is fully drained, erase all dead eclasses that
   // were deferred during classUnion.
-  // LLVM_DEBUG({
-  //   llvm::dbgs() << "Pending erases:\n";
-  //   for (equivalence::ClassOp dead : pendingErase) {
-  //     llvm::dbgs() << "\t";
-  //     dead.dump();
-  //   }
-  // });
+  LLVM_DEBUG({
+    llvm::dbgs() << "Pending erases:\n";
+    for (equivalence::ClassOp dead : pendingErase) {
+      llvm::dbgs() << "\t";
+      dead.dump();
+    }
+  });
   SmallPtrSet<Operation *, 8> erased;
   for (equivalence::ClassOp dead : pendingErase) {
     if (erased.insert(dead.getOperation()).second)
@@ -585,15 +274,6 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
   if (classOp->getBlock() == nullptr) {
     return;
   }
-
-  LLVM_DEBUG({
-    Value dupOperand = findFirstDuplicateInput(classOp);
-    if (dupOperand) {
-      logFirstDuplicateOnly("repair: entry", classOp, dupOperand);
-      logDuplicateClassOpState("repair: entry already violates uniqueness",
-                               classOp, dupOperand);
-    }
-  });
 
   llvm::DenseMap<Operation *, Operation *, SimpleOperationInfo> uniqueParents;
   // Collect pairs of duplicate operations to merge AFTER the loop
@@ -635,12 +315,7 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
       if (classKeep && classOther) {
         // Case 1: both values have a class — replace other's results with
         // keep's results, then union the two classes.
-        unsigned beforeResKeepUsers = countDistinctClassUsers(resKeep);
         rewriter.replaceAllUsesWith(resOther, resKeep);
-        LLVM_DEBUG({
-          logFirstClassUserFanoutTransition("repair/case1: replaceAllUsesWith",
-                                            resKeep, beforeResKeepUsers);
-        });
         // The replaceAllUsesWith above rewrote resOther -> resKeep inside
         // classOther's input list.  That means resKeep is now an input of
         // *both* classKeep and classOther, breaking the single-class-
@@ -655,7 +330,6 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
           }
           if (filtered.size() != otherInputs.size())
             otherInputs.assign(filtered);
-
           classUnion(rewriter, classKeep.getResult(), classOther.getResult());
         } else {
           SmallPtrSet<Value, 8> seen;
@@ -665,52 +339,23 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
               uniqueOperands.push_back(operand);
           }
           classKeep.getInputsMutable().assign(uniqueOperands);
-          LLVM_DEBUG({
-            logDuplicateClassOpState("repair: duplicate remains after dedupe",
-                                     classKeep);
-          });
         }
       } else if (classKeep) {
         // Case 2: only keep has a class — redirect other's results to the
         // class representative rather than the raw result.
-        unsigned beforeClassKeepUsers =
-            countDistinctClassUsers(classKeep.getResult());
         rewriter.replaceAllUsesWith(resOther, classKeep.getResult());
-        LLVM_DEBUG({
-          logFirstClassUserFanoutTransition("repair/case2: replaceAllUsesWith",
-                                            classKeep.getResult(),
-                                            beforeClassKeepUsers);
-        });
       } else if (classOther) {
         // Case 3: only other has a class — redirect keep's non-ClassOp users
         // through classOther first, then retarget classOther from resOther to
         // resKeep.
-        unsigned beforeClassOtherUsers =
-            countDistinctClassUsers(classOther.getResult());
         rewriter.replaceUsesWithIf(resKeep, classOther.getResult(),
                                    [&](OpOperand &operand) {
                                      return operand.getOwner() != classOther;
                                    });
-        LLVM_DEBUG({
-          logFirstClassUserFanoutTransition("repair/case3: replaceUsesWithIf",
-                                            classOther.getResult(),
-                                            beforeClassOtherUsers);
-        });
-        unsigned beforeResKeepUsers = countDistinctClassUsers(resKeep);
         rewriter.replaceAllUsesWith(resOther, resKeep);
-        LLVM_DEBUG({
-          logFirstClassUserFanoutTransition(
-              "repair/case3: replaceAllUsesWith(resOther,resKeep)", resKeep,
-              beforeResKeepUsers);
-        });
       } else {
         // Case 4: neither has a class — simple replacement.
-        unsigned beforeResKeepUsers = countDistinctClassUsers(resKeep);
         rewriter.replaceAllUsesWith(resOther, resKeep);
-        LLVM_DEBUG({
-          logFirstClassUserFanoutTransition("repair/case4: replaceAllUsesWith",
-                                            resKeep, beforeResKeepUsers);
-        });
       }
     }
     rewriter.eraseOp(other);

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -281,9 +281,10 @@ void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
   SmallPtrSet<Operation *, 8> scheduledForMerge;
   for (Operation *op1 : classOp.getResult().getUsers()) {
     // Skip ClassOps that use this result as their leader pointer.
-    if (auto op1class = llvm::dyn_cast<equivalence::ClassOp>(op1))
+    if (auto op1class = llvm::dyn_cast<equivalence::ClassOp>(op1)) {
       assert(op1class.getLeader() == classOp.getResult());
-    continue;
+      continue;
+    }
     Operation *op2 = uniqueParents.lookup(op1);
 
     if (op2) {


### PR DESCRIPTION
repair was basically not running, because I missed:
```
if (condition)
   dbgs() << ...
   continue
```
i.e. the continue was unconditionally being executed.

fixing this uncovered some further bugs, namely handling different cases of repair, where duplicate operation may or may not already have a class.