### PR TITLE
Fix hashcons invariant

### DIFF
--- a/include/Utils/ClassOpUnionFind.h
+++ b/include/Utils/ClassOpUnionFind.h
@@ -80,20 +80,31 @@ public:
   void hashconsGraph(HashConsPatternRewriter &rewriter,
                      equivalence::GraphOp graph);
 
-  /// Repair e-graph by potentially deduplicating the parents of
-  /// a merged ClassOp.
-  void repair(HashConsPatternRewriter &rewriter, equivalence::ClassOp classOp);
+  /// Repair e-graph by potentially deduplicating the parents (=users) of
+  /// the given operation.  When `op` is a ClassOp this dedups users of the
+  /// class result; for any other operation it dedups users of `op`'s
+  /// results.  A `keep` operation pushed to the worklist by `mergeResults`
+  /// is repaired this way so that newly redirected users that became
+  /// identical can be collapsed.
+  void repair(HashConsPatternRewriter &rewriter, mlir::Operation *op);
 
   /// Merge the results of two duplicate parent operations
   /// (`other` -> `keep`), reconciling their owning ClassOps if any.
   /// Used by `repair` when collapsing duplicate users of a ClassOp.
+  /// After redirecting `other`'s users onto `keep`, `keep` is pushed onto
+  /// the worklist so that any users that became identical are repaired in
+  /// the next rebuild iteration.
   void mergeResults(HashConsPatternRewriter &rewriter, mlir::Operation *other,
                     mlir::Operation *keep);
 
-  /// Worklist of ClassOps whose parents potentially need to be repaired.
-  /// Entries may become stale (operands cleared) if they were merged into
-  /// another class; such entries are skipped during rebuild.
-  SmallVector<equivalence::ClassOp> worklist;
+  /// Worklist of operations whose parents (=users) potentially need to be
+  /// repaired.  Entries may be ClassOps (added by `classUnion` whose
+  /// canonical leader needs to absorb the merged class) or arbitrary
+  /// operations (added by `mergeResults` because the redirected users may
+  /// have become identical).  Entries may become stale (detached or
+  /// erased) before being processed; such entries are skipped during
+  /// rebuild via an `op->getBlock()` check.
+  SmallVector<mlir::Operation *> worklist;
 
 private:
   SmallVector<equivalence::ClassOp> pendingErase;

--- a/include/Utils/ClassOpUnionFind.h
+++ b/include/Utils/ClassOpUnionFind.h
@@ -73,6 +73,13 @@ public:
   /// Returns false when the worklist was empty, otherwise true.
   bool rebuild(HashConsPatternRewriter &rewriter);
 
+  /// Create a hash-cons scope for the given graph's region and insert every
+  /// non-ClassOp operation into it. Duplicate operations encountered during
+  /// insertion are collected and merged via `mergeResults`, mirroring the
+  /// pair-collect-then-process pattern used by `repair`.
+  void hashconsGraph(HashConsPatternRewriter &rewriter,
+                     equivalence::GraphOp graph);
+
   /// Repair e-graph by potentially deduplicating the parents of
   /// a merged ClassOp.
   void repair(HashConsPatternRewriter &rewriter, equivalence::ClassOp classOp);

--- a/src/EmatchDialect.cpp
+++ b/src/EmatchDialect.cpp
@@ -146,16 +146,7 @@ bool runSaturation(MLIRContext *ctx, PDLPatternModule pdlPattern,
     hashconsRewriter.setListener(listener);
 
   irModule.walk([&](equivalence::GraphOp graph) {
-    Region *region = &(graph.getBody());
-    auto scope = hashconsRewriter.createRootScope(region);
-
-    graph->walk([&](Operation *op) {
-      if (dyn_cast<equivalence::ClassOp>(*op)) {
-        return;
-      }
-      scope->insert(op, op);
-      hashconsRewriter.setNodeCount(hashconsRewriter.getNodeCount() + 1);
-    });
+    uf.hashconsGraph(hashconsRewriter, graph);
   });
 
   pdlPattern.registerRewriteFunction("get_class_vals", getClassVals);

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -249,6 +249,42 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
   return true;
 }
 
+void ClassOpUnionFind::hashconsGraph(HashConsPatternRewriter &rewriter,
+                                     equivalence::GraphOp graph) {
+  TAMAGOYAKI_SCOPED_TIMER("hashconsGraph");
+
+  Region *region = &graph.getBody();
+  rewriter.createRootScope(region);
+
+  SmallVector<std::pair<Operation *, Operation *>> toMerge;
+  SmallPtrSet<Operation *, 8> scheduledForMerge;
+
+  for (Operation &opRef : graph.getBody().getOps()) {
+    Operation *op = &opRef;
+    if (llvm::isa<equivalence::ClassOp>(op))
+      continue;
+    if (succeeded(rewriter.insert(op)))
+      continue;
+
+    Operation *existing = rewriter.lookup(op);
+    assert(existing && existing != op &&
+           "insert failed but no duplicate found");
+    if (scheduledForMerge.insert(op).second)
+      toMerge.emplace_back(op, existing);
+  }
+
+  for (auto [other, keep] : toMerge) {
+    bool erased = rewriter.erase(keep).succeeded();
+    assert(erased);
+    bool inserted = rewriter.insert(keep).succeeded();
+    assert(inserted);
+
+    mergeResults(rewriter, other, keep);
+    rewriter.replaceOp(other, keep);
+  }
+  rebuild(rewriter);
+}
+
 void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
                               equivalence::ClassOp classOp) {
   if (classOp->getBlock() == nullptr) {

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -19,6 +19,8 @@
 #include "mlir/Support/LLVM.h"
 #include "vendor/mlir/SimpleOperationInfo.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -194,10 +196,32 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
   if (worklist.empty())
     return false;
 
+  // Track ops that get erased during the loop below. Operations queued in
+  // `todo` (or `worklist` re-entry) may be freed by `repair`'s
+  // `replaceOp`, so we must not dereference their pointers afterwards.
+  // Just checking `op->getBlock()` is unsafe because the Operation memory
+  // itself may have been freed.
+  SmallPtrSet<Operation *, 16> erasedOps;
+  struct EraseTracker : public RewriterBase::ForwardingListener {
+    EraseTracker(OpBuilder::Listener *previous,
+                 SmallPtrSet<Operation *, 16> &erased)
+        : RewriterBase::ForwardingListener(previous), erased(erased) {}
+    void notifyOperationErased(Operation *op) override {
+      erased.insert(op);
+      RewriterBase::ForwardingListener::notifyOperationErased(op);
+    }
+    SmallPtrSet<Operation *, 16> &erased;
+  };
+  OpBuilder::Listener *previousListener = rewriter.getListener();
+  EraseTracker tracker(previousListener, erasedOps);
+  rewriter.setListener(&tracker);
+  auto restoreListener =
+      llvm::scope_exit([&] { rewriter.setListener(previousListener); });
+
   while (!worklist.empty()) {
     llvm::SetVector<Operation *> todo;
     for (Operation *op : worklist) {
-      if (!op || !op->getBlock()) {
+      if (!op || erasedOps.contains(op) || !op->getBlock()) {
         continue; // op has already been removed/erased
       }
 
@@ -239,7 +263,7 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
     worklist.clear();
 
     for (Operation *op : todo) {
-      if (!op || !op->getBlock())
+      if (!op || erasedOps.contains(op) || !op->getBlock())
         continue;
       if (auto c = llvm::dyn_cast<equivalence::ClassOp>(op)) {
         if (c.getInputs().empty())

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -299,10 +299,6 @@ void ClassOpUnionFind::hashconsGraph(HashConsPatternRewriter &rewriter,
 
 void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
                               Operation *op) {
-  if (op == nullptr || op->getBlock() == nullptr) {
-    return;
-  }
-
   // For a ClassOp we look at users of its single class result; for any
   // other operation we look at users of all of its results.
   auto classOp = llvm::dyn_cast<equivalence::ClassOp>(op);
@@ -403,11 +399,5 @@ void ClassOpUnionFind::mergeResults(HashConsPatternRewriter &rewriter,
     }
   }
 
-  // After redirecting `other`'s users onto `keep`, the users of `keep`
-  // may have become identical and need to be deduplicated.  Schedule
-  // `keep` for repair in the next rebuild iteration.  The worklist
-  // entry will be skipped if `keep` is later detached or erased
-  // (checked via `op->getBlock()` in `rebuild`).
-  if (keep && keep->getBlock())
-    worklist.push_back(keep);
+  worklist.push_back(keep);
 }

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -188,17 +188,25 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
   TAMAGOYAKI_SCOPED_TIMER("rebuild");
   LLVM_DEBUG({
     llvm::dbgs() << "Starting rebuild. Worklist contains " << worklist.size()
-                 << " classes\n";
+                 << " entries\n";
   });
 
   if (worklist.empty())
     return false;
 
   while (!worklist.empty()) {
-    llvm::SetVector<equivalence::ClassOp> todo;
-    for (equivalence::ClassOp c : worklist) {
-      if (!c->getBlock()) {
-        continue; // c has already been removed
+    llvm::SetVector<Operation *> todo;
+    for (Operation *op : worklist) {
+      if (!op || !op->getBlock()) {
+        continue; // op has already been removed/erased
+      }
+
+      auto c = llvm::dyn_cast<equivalence::ClassOp>(op);
+      if (!c) {
+        // Non-ClassOp entries come from `mergeResults`: their users may
+        // have become identical and need to be deduplicated.
+        todo.insert(op);
+        continue;
       }
 
       auto leader = getCanonicalLeader(c);
@@ -226,14 +234,18 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
         c->remove();
         pendingErase.push_back(c);
       }
-      todo.insert(leader);
+      todo.insert(leader.getOperation());
     }
     worklist.clear();
 
-    for (equivalence::ClassOp c : todo) {
-      if (c.getInputs().empty())
+    for (Operation *op : todo) {
+      if (!op || !op->getBlock())
         continue;
-      repair(rewriter, c);
+      if (auto c = llvm::dyn_cast<equivalence::ClassOp>(op)) {
+        if (c.getInputs().empty())
+          continue;
+      }
+      repair(rewriter, op);
     }
   }
 
@@ -286,21 +298,28 @@ void ClassOpUnionFind::hashconsGraph(HashConsPatternRewriter &rewriter,
 }
 
 void ClassOpUnionFind::repair(HashConsPatternRewriter &rewriter,
-                              equivalence::ClassOp classOp) {
-  if (classOp->getBlock() == nullptr) {
+                              Operation *op) {
+  if (op == nullptr || op->getBlock() == nullptr) {
     return;
   }
+
+  // For a ClassOp we look at users of its single class result; for any
+  // other operation we look at users of all of its results.
+  auto classOp = llvm::dyn_cast<equivalence::ClassOp>(op);
 
   llvm::DenseMap<Operation *, Operation *, SimpleOperationInfo> uniqueParents;
   // Collect pairs of duplicate operations to merge AFTER the loop
   SmallVector<std::pair<Operation *, Operation *>> toMerge;
 
   SmallPtrSet<Operation *, 8> scheduledForMerge;
-  for (Operation *op1 : classOp.getResult().getUsers()) {
-    // Skip ClassOps that use this result as their leader pointer.
-    if (auto op1class = llvm::dyn_cast<equivalence::ClassOp>(op1)) {
-      assert(op1class.getLeader() == classOp.getResult());
-      continue;
+
+  for (Operation *op1 : op->getUsers()) {
+    if (classOp) {
+      // Skip ClassOps that use this result as their leader pointer.
+      if (auto op1class = llvm::dyn_cast<equivalence::ClassOp>(op1)) {
+        assert(op1class.getLeader() == classOp.getResult());
+        continue;
+      }
     }
     Operation *op2 = uniqueParents.lookup(op1);
 
@@ -383,4 +402,12 @@ void ClassOpUnionFind::mergeResults(HashConsPatternRewriter &rewriter,
       rewriter.replaceAllUsesWith(resOther, resKeep);
     }
   }
+
+  // After redirecting `other`'s users onto `keep`, the users of `keep`
+  // may have become identical and need to be deduplicated.  Schedule
+  // `keep` for repair in the next rebuild iteration.  The worklist
+  // entry will be skipped if `keep` is later detached or erased
+  // (checked via `op->getBlock()` in `rebuild`).
+  if (keep && keep->getBlock())
+    worklist.push_back(keep);
 }

--- a/test/lit/hashconsgraph.mlir
+++ b/test/lit/hashconsgraph.mlir
@@ -1,0 +1,23 @@
+// RUN: %tamagoyaki --ematch-saturate=max-iters=0 %s | FileCheck %s
+
+module @ir {
+
+    // CHECK:      equivalence.graph -> (i32, i32) {
+    // CHECK-NEXT:     %0 = arith.constant 1 : i32
+    // CHECK-NEXT:     %1 = arith.addi %a, %a : i32
+    // CHECK-NEXT:     equivalence.yield %1, %1, %1 : i32, i32, i32
+    // CHECK-NEXT: }
+
+    %0:2 = equivalence.graph -> (i32, i32) {
+        %a = arith.constant 1 : i32
+        %a_dup = arith.constant 1 : i32
+        
+        %1 = arith.addi %a, %a : i32
+        %2 = arith.addi %a_dup, %a_dup : i32
+        %3 = arith.addi %a_dup, %a : i32
+    
+        equivalence.yield %1, %2, %3 : i32, i32, i32
+    }
+}
+
+module @patterns {}

--- a/test/lit/hashconsgraph.mlir
+++ b/test/lit/hashconsgraph.mlir
@@ -1,10 +1,10 @@
-// RUN: %tamagoyaki --ematch-saturate=max-iters=0 %s | FileCheck %s
+// RUN: tamagoyaki-opt --ematch-saturate=max-iters=0 %s | FileCheck %s
 
 module @ir {
 
-    // CHECK:      equivalence.graph -> (i32, i32) {
-    // CHECK-NEXT:     %0 = arith.constant 1 : i32
-    // CHECK-NEXT:     %1 = arith.addi %a, %a : i32
+    // CHECK:      %0:2 = equivalence.graph -> (i32, i32) {
+    // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+    // CHECK-NEXT:     %1 = arith.addi %c1_i32, %c1_i32 : i32
     // CHECK-NEXT:     equivalence.yield %1, %1, %1 : i32, i32, i32
     // CHECK-NEXT: }
 


### PR DESCRIPTION
Rebuilding did not properly work for the case where two identical parents that are merged weren't both part of an eclass. If this was the case, the merged operation was not pushed to the worklist. The worklist contained only `equivalence.class` operations while it should also contain regular operations (their users can also have become identical after a merge)

Additionally, `runSaturation` will iterate over the operations in a `equivalence.graph` and deduplicate operations properly.