### PR TITLE
Add `equivalence.class` verifier

### DIFF
--- a/include/EquivalenceDialect.td
+++ b/include/EquivalenceDialect.td
@@ -122,6 +122,8 @@ def Equivalence_GraphOp : Equivalence_Op<"graph", [
     let assemblyFormat = [{
         ( `->` `(` type($outputs)^ `)` )? $body attr-dict
     }];
+
+    let hasVerifier = 1; 
 }
 
 

--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -106,9 +106,12 @@ LogicalResult GraphOp::verify() {
   auto walkResult = getBody().walk([&](Operation *op) -> WalkResult {
     if (isa<YieldOp>(op))
       return WalkResult::advance();
-    if (!op->hasTrait<OpTrait::AlwaysSpeculatableImplTrait>()) {
-      return op->emitOpError("operation in equivalence.graph region must be "
-                             "AlwaysSpeculatable");
+    if (!op->hasTrait<OpTrait::AlwaysSpeculatableImplTrait>() &&
+        !op->hasAttrOfType<UnitAttr>("equivalence.allow_unspeculatable")) {
+      return op->emitOpError(
+          "operation in equivalence.graph region must be "
+          "AlwaysSpeculatable or carry the "
+          "`equivalence.allow_unspeculatable` unit attribute");
     }
     return WalkResult::advance();
   });

--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -102,6 +102,8 @@ LogicalResult ClassOp::verify() {
   return success();
 }
 
+LogicalResult GraphOp::verify() { return success(); }
+
 //===----------------------------------------------------------------------===//
 // Equivalence passes
 //===----------------------------------------------------------------------===//

--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -102,7 +102,18 @@ LogicalResult ClassOp::verify() {
   return success();
 }
 
-LogicalResult GraphOp::verify() { return success(); }
+LogicalResult GraphOp::verify() {
+  auto walkResult = getBody().walk([&](Operation *op) -> WalkResult {
+    if (isa<YieldOp>(op))
+      return WalkResult::advance();
+    if (!op->hasTrait<OpTrait::AlwaysSpeculatableImplTrait>()) {
+      return op->emitOpError("operation in equivalence.graph region must be "
+                             "AlwaysSpeculatable");
+    }
+    return WalkResult::advance();
+  });
+  return failure(walkResult.wasInterrupted());
+}
 
 //===----------------------------------------------------------------------===//
 // Equivalence passes

--- a/test/lit/ematch_mul_to_shift.mlir
+++ b/test/lit/ematch_mul_to_shift.mlir
@@ -105,7 +105,7 @@ module @ir {
     // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
     // CHECK-NEXT:     %3 = arith.shli %1, %c1_i32 : i32
     // CHECK-NEXT:     %4 = arith.muli %1, %2 : i32
-    // CHECK-NEXT:     %5 = "test.op"() : () -> i32
+    // CHECK-NEXT:     %5 = "test.op"() {equivalence.allow_unspeculatable} : () -> i32
     // CHECK-NEXT:     %6 = equivalence.class %5, %4, %3 : i32
     // CHECK-NEXT:     equivalence.yield %6 : i32
     // CHECK-NEXT:   }
@@ -118,7 +118,7 @@ module @ir {
             %c2_i32 = arith.constant 2 : i32
             %2 = equivalence.class %c2_i32 : i32
             %3 = arith.muli %1, %2 : i32
-            %someotherval = "test.op"() : () -> (i32)
+            %someotherval = "test.op"() {equivalence.allow_unspeculatable} : () -> (i32)
             %4 = equivalence.class %someotherval, %3 : i32
             equivalence.yield %4 : i32
         }

--- a/test/lit/ematch_mul_to_shift_split/ir.mlir
+++ b/test/lit/ematch_mul_to_shift_split/ir.mlir
@@ -8,7 +8,7 @@
 // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
 // CHECK-NEXT:     %3 = arith.shli %1, %c1_i32 : i32
 // CHECK-NEXT:     %4 = arith.muli %1, %2 : i32
-// CHECK-NEXT:     %5 = "test.op"() : () -> i32
+// CHECK-NEXT:     %5 = "test.op"() {equivalence.allow_unspeculatable} : () -> i32
 // CHECK-NEXT:     %6 = equivalence.class %5, %4, %3 : i32
 // CHECK-NEXT:     equivalence.yield %6 : i32
 // CHECK-NEXT:   }
@@ -21,7 +21,7 @@ func.func @graph_with_eqs(%arg0: i32) -> i32 {
         %c2_i32 = arith.constant 2 : i32
         %2 = equivalence.class %c2_i32 : i32
         %3 = arith.muli %1, %2 : i32
-        %someotherval = "test.op"() : () -> (i32)
+        %someotherval = "test.op"() {equivalence.allow_unspeculatable} : () -> (i32)
         %4 = equivalence.class %someotherval, %3 : i32
         equivalence.yield %4 : i32
     }

--- a/test/lit/equivalence-ops-errors.mlir
+++ b/test/lit/equivalence-ops-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: tamagoyaki-opt --verify-diagnostics %s
+// RUN: tamagoyaki-opt --verify-diagnostics -allow-unregistered-dialect %s
 
 // ===----------------------------------------------------------------------===//
 // Test equivalence.class verification - error cases
@@ -30,4 +30,28 @@ func.func @test_class_operand_multiple_users() {
     %1 = equivalence.class %0 : i32
     %2 = equivalence.class %0 : i32
     return
+}
+
+// ===----------------------------------------------------------------------===//
+// Test equivalence.graph verification - error cases
+// ===----------------------------------------------------------------------===//
+
+// Test: graph region cannot contain operations that are not AlwaysSpeculatable
+func.func @test_graph_unspeculatable_op() -> i32 {
+    %0 = equivalence.graph -> (i32) {
+        // expected-error@+1 {{operation in equivalence.graph region must be AlwaysSpeculatable}}
+        %1 = "test.op"() : () -> (i32)
+        equivalence.yield %1 : i32
+    }
+    return %0 : i32
+}
+
+// Test: unspeculatable operation is allowed when carrying the
+// `equivalence.allow_unspeculatable` unit attribute.
+func.func @test_graph_unspeculatable_op_allowed() -> i32 {
+    %0 = equivalence.graph -> (i32) {
+        %1 = "test.op"() {equivalence.allow_unspeculatable} : () -> (i32)
+        equivalence.yield %1 : i32
+    }
+    return %0 : i32
 }


### PR DESCRIPTION
This verifies that all operations contained in the graph are AlwaysSpeculatable, unless they have an attribute `equivalence.allow_unspeculatable`.
I decided not to verify the hashcons invariant at this point: I just [pushed some changes](https://github.com/jumerckx/Tamagoyaki/blob/main/test/lit/hashconsgraph.mlir) to deduplicate operations and rebuild the graph at the start of equality saturation.