### PR TITLE
Add c++ test infra

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ if(ENABLE_ASAN)
   add_link_options(-fsanitize=address)
 endif()
 
+# Build the test-only passes in test/lib/ and link them into tamagoyaki-opt.
+# These passes are not part of the Tamagoyaki core; they exist solely to drive
+# lit/FileCheck tests (mirrors MLIR's MLIR_INCLUDE_TESTS option).
+option(TAMAGOYAKI_INCLUDE_TESTS
+       "Build test-only passes and link them into tamagoyaki-opt" ON)
+
 find_package(MLIR REQUIRED CONFIG)
 
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,9 +86,16 @@ set(TAMAGOYAKI_OPT_LIBS
   TamagoyakiTiming
 )
 
+if(TAMAGOYAKI_INCLUDE_TESTS)
+  list(APPEND TAMAGOYAKI_OPT_LIBS TamagoyakiTestPasses)
+endif()
+
 add_llvm_executable(tamagoyaki-opt tamagoyaki-opt.cpp)
 llvm_update_compile_flags(tamagoyaki-opt)
 target_link_libraries(tamagoyaki-opt PRIVATE ${TAMAGOYAKI_OPT_LIBS})
+if(TAMAGOYAKI_INCLUDE_TESTS)
+  target_compile_definitions(tamagoyaki-opt PRIVATE TAMAGOYAKI_INCLUDE_TESTS)
+endif()
 add_dependencies(tamagoyaki-opt
   MLIREquivalenceIncGen
   MLIREmatchIncGen

--- a/src/tamagoyaki-opt.cpp
+++ b/src/tamagoyaki-opt.cpp
@@ -18,12 +18,27 @@ using namespace mlir;
 using namespace mlir::equivalence;
 using namespace mlir::ematch;
 
+#ifdef TAMAGOYAKI_INCLUDE_TESTS
+// Test-only passes defined in test/lib/. They have no public header and are
+// only available when the build is configured with TAMAGOYAKI_INCLUDE_TESTS.
+namespace mlir::test {
+void registerTestEquivalenceUtilsPasses();
+} // namespace mlir::test
+
+static void registerTestPasses() {
+  mlir::test::registerTestEquivalenceUtilsPasses();
+}
+#endif
+
 int main(int argc, char **argv) {
   tamagoyaki::registerTimingCLOptions();
 
   mlir::registerAllPasses();
   mlir::equivalence::registerEquivalencePasses();
   mlir::ematch::registerEmatchPasses();
+#ifdef TAMAGOYAKI_INCLUDE_TESTS
+  registerTestPasses();
+#endif
   mlir::DialectRegistry registry;
   registry.insert<mlir::equivalence::EquivalenceDialect,
                   mlir::ematch::EmatchDialect>();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,10 @@
+# Test-only pass library, linked into tamagoyaki-opt (see src/CMakeLists.txt).
+if(TAMAGOYAKI_INCLUDE_TESTS)
+  add_subdirectory(lib)
+endif()
+
 llvm_canonicalize_cmake_booleans(MLIR_ENABLE_BINDINGS_PYTHON)
+llvm_canonicalize_cmake_booleans(TAMAGOYAKI_INCLUDE_TESTS)
 
 # this configures the adjacent lit.site.cfg.py.in
 set(TAMAGOYAKI_BINARY_DIR ${PROJECT_BINARY_DIR})

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Test-only passes. This library is built and linked into tamagoyaki-opt only
+# when TAMAGOYAKI_INCLUDE_TESTS is enabled (see the top-level CMakeLists.txt).
+# It mirrors MLIR's test/lib/ convention: passes here are not part of the
+# Tamagoyaki core and exist purely to drive lit/FileCheck tests. Add new
+# test-pass source files to this list and register them from
+# src/tamagoyaki-opt.cpp behind #ifdef TAMAGOYAKI_INCLUDE_TESTS.
+add_mlir_library(TamagoyakiTestPasses
+  TestEquivalenceUtils.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include
+
+  DEPENDS
+  MLIREquivalenceIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIREquivalence
+)

--- a/test/lib/TestEquivalenceUtils.cpp
+++ b/test/lib/TestEquivalenceUtils.cpp
@@ -1,0 +1,62 @@
+//===- TestEquivalenceUtils.cpp - Test passes for EquivalenceUtils --------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains test-only passes that exercise the internal helpers in
+// EquivalenceUtils.h which are not otherwise reachable from a production pass.
+// These passes are NOT part of the Tamagoyaki core; they are compiled into
+// tamagoyaki-opt only when TAMAGOYAKI_INCLUDE_TESTS is enabled and exist purely
+// to drive lit/FileCheck tests, mirroring MLIR's own test/lib/ pattern.
+//
+//===----------------------------------------------------------------------===//
+
+#include "EquivalenceDialect.h"
+#include "EquivalenceUtils.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+using namespace mlir::equivalence;
+
+namespace {
+/// Exercises EquivalenceUtils::computeGraphCosts with the `costReductionMax`
+/// reduction and a uniform per-node cost of 1. The returned cost map is written
+/// back onto each operation as a `test.cost` integer attribute so the result
+/// can be checked with FileCheck. No production pass uses the max-reduction, so
+/// this verifies that internal helper independently of the rest of the
+/// pipeline.
+struct TestEquivalenceGraphCostPass
+    : public PassWrapper<TestEquivalenceGraphCostPass,
+                         OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestEquivalenceGraphCostPass)
+
+  StringRef getArgument() const final { return "test-equivalence-graph-cost"; }
+  StringRef getDescription() const final {
+    return "Annotate each op in every equivalence.graph with the max-reduction "
+           "cost computed by EquivalenceUtils (test only)";
+  }
+
+  void runOnOperation() override {
+    getOperation().walk([](GraphOp graphOp) {
+      DenseMap<Operation *, int64_t> costs =
+          computeGraphCosts(graphOp, /*defaultCost=*/1,
+                            /*costAttributeName=*/"test.cost", costReductionMax);
+      for (auto &[op, cost] : costs)
+        op->setAttr("test.cost", Builder(op).getI64IntegerAttr(cost));
+    });
+  }
+};
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestEquivalenceUtilsPasses() {
+  PassRegistration<TestEquivalenceGraphCostPass>();
+}
+} // namespace test
+} // namespace mlir

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -54,6 +54,11 @@ tools = ["tamagoyaki-opt"]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
+# Expose whether tamagoyaki-opt was built with the test-only passes (test/lib/).
+# Tests that rely on a `test-*` pass should guard with: REQUIRES: tamagoyaki-tests
+if getattr(config, "tamagoyaki_include_tests", False):
+    config.available_features.add("tamagoyaki-tests")
+
 llvm_config.with_environment(
     "PYTHONPATH",
     [

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -5,6 +5,7 @@ config.mlir_obj_dir = "@MLIR_BINARY_DIR@"
 config.tamagoyaki_obj_root = "@TAMAGOYAKI_BINARY_DIR@"
 config.tamagoyaki_src_root = "@TAMAGOYAKI_SOURCE_DIR@"
 config.llvm_shlib_ext = "@SHLIBEXT@"
+config.tamagoyaki_include_tests = @TAMAGOYAKI_INCLUDE_TESTS@
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/test/lit/test-equivalence-graph-cost.mlir
+++ b/test/lit/test-equivalence-graph-cost.mlir
@@ -1,0 +1,23 @@
+// RUN: tamagoyaki-opt --test-equivalence-graph-cost %s | FileCheck %s
+
+// This exercises a test-only pass (test/lib/TestEquivalenceUtils.cpp) which is
+// only available when tamagoyaki-opt is built with TAMAGOYAKI_INCLUDE_TESTS.
+// REQUIRES: tamagoyaki-tests
+
+func.func @main(%arg0: i32) -> i32 {
+  %0 = equivalence.graph -> (i32) {
+    // Leaf nodes have base cost 1 and no (in-graph) operands.
+    // CHECK: arith.muli %arg0, %arg0 {test.cost = 1 : i64}
+    %a = arith.muli %arg0, %arg0 : i32
+    // CHECK: arith.constant {test.cost = 1 : i64} 5
+    %c5 = arith.constant 5 : i32
+    // The class cost is the min over its operands (both 1).
+    // CHECK: equivalence.class {{.*}} {test.cost = 1 : i64}
+    %k1 = equivalence.class %a, %c5 : i32
+    // max-reduction: base cost 1 + max(child costs) = 1 + 1 = 2.
+    // CHECK: arith.addi {{.*}} {test.cost = 2 : i64}
+    %r = arith.addi %k1, %k1 : i32
+    equivalence.yield %r : i32
+  }
+  return %0 : i32
+}


### PR DESCRIPTION
This adds a place to add test-specific passes and other code that shouldn't live in the tamagoyaki core