### PR TITLE
fix congruence invariant issue

### DIFF
--- a/include/Utils/ClassOpUnionFind.h
+++ b/include/Utils/ClassOpUnionFind.h
@@ -88,6 +88,12 @@ public:
   /// identical can be collapsed.
   void repair(HashConsPatternRewriter &rewriter, mlir::Operation *op);
 
+  /// `dup` was found congruent to an existing e-node while being re-keyed
+  /// after an operand change. Schedule `repair` (via the worklist) so the
+  /// duplicate is collapsed through the same path as any other duplicate
+  /// parent. Safe to call mid-`rebuild`.
+  void repairDuplicate(mlir::Operation *dup);
+
   /// Merge the results of two duplicate parent operations
   /// (`other` -> `keep`), reconciling their owning ClassOps if any.
   /// Used by `repair` when collapsing duplicate users of a ClassOp.

--- a/include/Utils/HashConsPatternRewriter.h
+++ b/include/Utils/HashConsPatternRewriter.h
@@ -23,6 +23,8 @@
 
 namespace mlir::ematch {
 
+class ClassOpUnionFind;
+
 /// Allocator type for hash consing
 using AllocatorTy = llvm::RecyclingAllocator<
     llvm::BumpPtrAllocator,
@@ -70,8 +72,15 @@ public:
   /// Set the current node count
   void setNodeCount(uint64_t count) { nodeCount = count; }
 
+  /// Register the union-find so that congruences discovered while re-keying
+  /// modified ops (see `finalizeOpModification`) can be turned into unions.
+  void setUnionFind(ClassOpUnionFind *uf) { unionFind = uf; }
+
 private:
   ScopedMapTy hashcons;
+
+  /// Union-find used to reconcile congruences detected during op modification.
+  ClassOpUnionFind *unionFind = nullptr;
 
   /// Maps regions to their corresponding hash-cons scopes
   llvm::DenseMap<Region *, std::unique_ptr<ScopedMapTy::ScopeTy>> scopeMap;

--- a/src/EmatchDialect.cpp
+++ b/src/EmatchDialect.cpp
@@ -60,16 +60,16 @@ void mlir::ematch::EmatchDialect::initialize() {
       >();
 }
 
-mlir::Type mlir::ematch::EmatchDialect::parseType(
-    mlir::DialectAsmParser &parser) const {
+mlir::Type
+mlir::ematch::EmatchDialect::parseType(mlir::DialectAsmParser &parser) const {
   StringRef typeName;
   if (parser.parseKeyword(&typeName))
     return Type();
   return {};
 }
 
-void mlir::ematch::EmatchDialect::printType(
-    mlir::Type type, mlir::DialectAsmPrinter &os) const {
+void mlir::ematch::EmatchDialect::printType(mlir::Type type,
+                                            mlir::DialectAsmPrinter &os) const {
   os << "unknown";
 }
 
@@ -145,6 +145,7 @@ bool runSaturation(MLIRContext *ctx, PDLPatternModule pdlPattern,
 
   ClassOpUnionFind uf{};
   HashConsPatternRewriter hashconsRewriter(ctx);
+  hashconsRewriter.setUnionFind(&uf);
   if (listener)
     hashconsRewriter.setListener(listener);
 

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -24,6 +24,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstddef>
 #include <utility>
@@ -197,6 +198,23 @@ void ClassOpUnionFind::processPendingClassUnions(PatternRewriter &rewriter) {
   pendingClassUnions.clear();
 }
 
+void ClassOpUnionFind::repairDuplicate(Operation *dup) {
+  // `dup` was found congruent to an existing e-node while being re-keyed after
+  // an operand change. Both share operands, so scheduling repair of an
+  // operand-defining op lets repair()'s normal duplicate-merging path collapse
+  // them.
+  for (Value operand : dup->getOperands())
+    if (Operation *def = operand.getDefiningOp()) {
+      worklist.push_back(def);
+      return;
+    }
+
+  // The congruence is detected while re-keying `dup` after one of its operands
+  // was rewritten to a ClassOp result, so at least one operand must have a
+  // defining op. If none does, the duplicate would silently leak.
+  llvm_unreachable("repairDuplicate: congruent op has no defining-op operand");
+}
+
 bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
   TAMAGOYAKI_SCOPED_TIMER("rebuild");
   LLVM_DEBUG({
@@ -231,7 +249,9 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
 
   while (!worklist.empty()) {
     llvm::SetVector<Operation *> todo;
-    for (Operation *op : worklist) {
+    SmallVector<Operation *> current;
+    std::swap(current, worklist);
+    for (Operation *op : current) {
       if (!op || erasedOps.contains(op) || !op->getBlock()) {
         continue; // op has already been removed/erased
       }
@@ -271,7 +291,6 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
       }
       todo.insert(leader.getOperation());
     }
-    worklist.clear();
 
     for (Operation *op : todo) {
       if (!op || erasedOps.contains(op) || !op->getBlock())

--- a/src/Utils/HashConsPatternRewriter.cpp
+++ b/src/Utils/HashConsPatternRewriter.cpp
@@ -8,6 +8,7 @@
 
 #include "Utils/HashConsPatternRewriter.h"
 #include "EquivalenceDialect.h"
+#include "Utils/ClassOpUnionFind.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
@@ -50,7 +51,9 @@ void HashConsPatternRewriter::finalizeOpModification(Operation *op) {
                           << "\n");
   if (dyn_cast<equivalence::ClassOp>(*op))
     return;
-  (void)insert(op);
+  if (failed(insert(op)) && unionFind) {
+    unionFind->repairDuplicate(op);
+  }
   PatternRewriter::finalizeOpModification(op);
 }
 


### PR DESCRIPTION
This issue was uncovered when comparing against egg for larger numbers of saturation iterations. The issue was that `finalizeOpModification` could fail because the modified operation was already contained in the hashcons. In that case, there was no proper handling for the duplicate operations, the insertion in the hashcons failed, but the duplicate remained in IR, leading to more matches, more blowup.

The fix implemented here is to take the first non-block arg of the duplicate operation and add its defining operation to the worklist. That way, its users will be considered during rebuild. Note that this is not super efficient: if the operation we queue on the worklist has many uses, many users might be unnecessarily considered. 


As summarized by Claude:
```
  The bug: finalizeOpModification detects a congruence collision and throws it away

  When rebuild canonicalizes a class c into its leader, it rewrites the operands of every parent (ClassOpUnionFind.cpp:264):

  rewriter.replaceAllUsesWith(c.getResult(), leader.getResult());

  As you pointed out, that goes through modifyOpInPlace → startOpModification / finalizeOpModification, so each parent is erased from the hash-cons under its old key and re-inserted
  under its new (canonical) key. That re-insert is exactly where a parent can turn out to be congruent to an op that already exists — and the trace confirms all 19/116/1053 collisions
  originate from the finalize path.

  Look at what finalizeOpModification does with that fact (HashConsPatternRewriter.cpp:48-55):

  void HashConsPatternRewriter::finalizeOpModification(Operation *op) {
    if (dyn_cast<equivalence::ClassOp>(*op)) return;
    (void)insert(op);                       // <-- return value DISCARDED
    PatternRewriter::finalizeOpModification(op);
  }

  and insert on collision (HashConsPatternRewriter.cpp:87-92):

  if (auto existing = scope->lookup(op); existing.has_value()) {
    LLVM_DEBUG(... "equivalent operation already exists" ...);
    return failure();                       // <-- detected congruence, then nothing
  }

  So when a re-keyed op becomes congruent to an existing e-node, the code detects the congruence and then silently drops it: it does not union the two e-classes, and it does not
  erase/redirect the now-duplicate op. The modified op is left live in the IR — a congruent duplicate that isn't even in the hash-cons.
```