### PR TITLE
Avoid double lookup

### DIFF
--- a/include/Utils/MutableScopedHashTable.h
+++ b/include/Utils/MutableScopedHashTable.h
@@ -83,10 +83,15 @@ public:
     return ParentScope;
   }
 
-  /// Insert a key-value pair into THIS scope
-  void insert(const K &Key, const V &Val) {
-    ValTy *NewVal = ValTy::Create(Key, Val, HT.getAllocator());
-    LocalMap[Key] = NewVal;
+  /// Insert a key-value pair into THIS scope.
+  /// Returns true when Key was inserted.
+  /// Return false when Key was already present.
+  bool insert(const K &Key, const V &Val) {
+    auto [it, inserted] = LocalMap.try_emplace(Key, nullptr);
+    if (inserted) {
+      it->second = ValTy::Create(Key, Val, HT.getAllocator());
+    }
+    return inserted;
   }
 
   /// Lookup a key, searching this scope and all ancestors

--- a/src/Utils/HashConsPatternRewriter.cpp
+++ b/src/Utils/HashConsPatternRewriter.cpp
@@ -87,14 +87,13 @@ LogicalResult HashConsPatternRewriter::insert(Operation *op) {
   assert(scope && "insert: no scope registered for region");
 
   // Check if an equivalent operation already exists in the scope
-  if (auto existing = scope->lookup(op); existing.has_value()) {
+  if (!scope->insert(op, op)) {
     LLVM_DEBUG(llvm::dbgs()
-               << "insert: equivalent operation already exists: " << *existing
+               << "insert: equivalent operation already exists"
                << ", skipping insert of: " << *op << "\n");
     return failure();
   }
 
-  scope->insert(op, op);
   nodeCount++;
   LLVM_DEBUG(llvm::dbgs() << "inserted operation into hash-cons scope: " << *op
                           << "\n");


### PR DESCRIPTION
```
Benchmark 1: ./build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=7" -mlir-timing -debug-only=ematch
  Time (mean ± σ):     719.4 ms ±   9.3 ms    [User: 698.5 ms, System: 18.6 ms]
  Range (min … max):   706.6 ms … 734.1 ms    10 runs

Benchmark 2: ./build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=7" -mlir-timing -debug-only=ematch
  Time (mean ± σ):     755.7 ms ±  15.7 ms    [User: 736.5 ms, System: 15.7 ms]
  Range (min … max):   732.0 ms … 779.5 ms    10 runs

Summary
  ./build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=7" -mlir-timing -debug-only=ematch ran
    1.05 ± 0.03 times faster than ./build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=7" -mlir-timing -debug-only=ematch
```

Not much gain, but trivial.