### PR TITLE
separate e-graph invariants from `equivalence.class` operation legality

### DIFF
--- a/include/EquivalenceDialect.h
+++ b/include/EquivalenceDialect.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/include/EquivalenceDialect.td
+++ b/include/EquivalenceDialect.td
@@ -161,11 +161,11 @@ def Equivalence_ClassOp : Equivalence_Op<"class", [
 
     // Verify only the always-true structural invariants:
     // 1. At least one operand.
-    // 2. Operands are unique.
-    // 3. If present, the leader is the result of a ClassOp.
+    // 2. If present, the leader is the result of a ClassOp.
     // The normal-form properties (a class result is never an operand of another
-    // class; operands are used only by the class) are established by the
-    // `equivalence-restore-invariants` pass, not enforced here.
+    // class; operands are used only by the class; operands are unique) are
+    // established by the `equivalence-restore-invariants` pass, not enforced
+    // here.
     let hasVerifier = 1;
 }
 

--- a/include/EquivalenceDialect.td
+++ b/include/EquivalenceDialect.td
@@ -152,12 +152,18 @@ def Equivalence_ClassOp : Equivalence_Op<"class", [
     }];
 
     let hasFolder = 1;
-    
+
+    // For each operand, redirect any *other* op that still refers to the
+    // operand directly so that it refers to the class result instead. This
+    // establishes the invariant the verifier checks: a class's operands are
+    // only used by the class operation.
+    let hasCanonicalizeMethod = 1;
+
     // Verify the following:
     // 1. At least one operand.
     // 2. Operands cannot be result of other ClassOp.
     // 3. Operands must be used only by this ClassOp.
-    let hasVerifier = 1; 
+    let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/EquivalenceDialect.td
+++ b/include/EquivalenceDialect.td
@@ -153,16 +153,19 @@ def Equivalence_ClassOp : Equivalence_Op<"class", [
 
     let hasFolder = 1;
 
-    // For each operand, redirect any *other* op that still refers to the
-    // operand directly so that it refers to the class result instead. This
-    // establishes the invariant the verifier checks: a class's operands are
-    // only used by the class operation.
+    // Establishes the class normal form: merges a nested class operand into
+    // this class, and redirects any *other* op that still refers to an operand
+    // directly so that it refers to the class result instead. These are the
+    // structural rewrites the verifier no longer enforces.
     let hasCanonicalizeMethod = 1;
 
-    // Verify the following:
+    // Verify only the always-true structural invariants:
     // 1. At least one operand.
-    // 2. Operands cannot be result of other ClassOp.
-    // 3. Operands must be used only by this ClassOp.
+    // 2. Operands are unique.
+    // 3. If present, the leader is the result of a ClassOp.
+    // The normal-form properties (a class result is never an operand of another
+    // class; operands are used only by the class) are established by the
+    // `equivalence-restore-invariants` pass, not enforced here.
     let hasVerifier = 1;
 }
 
@@ -234,6 +237,26 @@ def EquivalenceSelectConstants: Pass<"equivalence-select-constants", "::mlir::Mo
     classes that contain an operand produced by a constant operation, selects
     that operand. Classes that already carry a `min_cost_index`, or that contain
     no constant operand, are left untouched.
+  }];
+  let dependentDialects = ["::mlir::equivalence::EquivalenceDialect"];
+}
+
+def EquivalenceRestoreInvariants: Pass<"equivalence-restore-invariants", "::mlir::ModuleOp"> {
+  let summary = "Restores the equivalence-class normal form to a fixpoint.";
+  let description = [{
+    Applies the `equivalence.class` folder and canonicalizer until no further
+    rewrites apply, re-establishing the class normal form:
+
+      * a class result is never used as an operand of another class
+        (nested classes are merged), and
+      * a class's operands are used only by that class
+        (external uses are rerouted through the class result).
+
+    Unlike the general `--canonicalize` pass, which caps the number of greedy
+    iterations and so only *attempts* to reach a fixpoint, this pass runs the
+    greedy driver with no iteration or rewrite limit. It is the mandatory,
+    deterministic normalization step that downstream passes depend on, in
+    contrast to opportunistic canonicalization.
   }];
   let dependentDialects = ["::mlir::equivalence::EquivalenceDialect"];
 }

--- a/include/EquivalenceDialect.td
+++ b/include/EquivalenceDialect.td
@@ -155,11 +155,10 @@ def Equivalence_ClassOp : Equivalence_Op<"class", [
 
     // Establishes the class normal form: merges a nested class operand into
     // this class, and redirects any *other* op that still refers to an operand
-    // directly so that it refers to the class result instead. These are the
-    // structural rewrites the verifier no longer enforces.
+    // directly so that it refers to the class result instead.
     let hasCanonicalizeMethod = 1;
 
-    // Verify only the always-true structural invariants:
+    // Verify:
     // 1. At least one operand.
     // 2. If present, the leader is the result of a ClassOp.
     // The normal-form properties (a class result is never an operand of another
@@ -251,12 +250,7 @@ def EquivalenceRestoreInvariants: Pass<"equivalence-restore-invariants", "::mlir
         (nested classes are merged), and
       * a class's operands are used only by that class
         (external uses are rerouted through the class result).
-
-    Unlike the general `--canonicalize` pass, which caps the number of greedy
-    iterations and so only *attempts* to reach a fixpoint, this pass runs the
-    greedy driver with no iteration or rewrite limit. It is the mandatory,
-    deterministic normalization step that downstream passes depend on, in
-    contrast to opportunistic canonicalization.
+      * class operands are deduplicated
   }];
   let dependentDialects = ["::mlir::equivalence::EquivalenceDialect"];
 }

--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -74,6 +74,13 @@ mlir::RegionKind GraphOp::getRegionKind(unsigned index) {
 } // namespace mlir::equivalence
 
 mlir::LogicalResult mlir::equivalence::ClassOp::verify() {
+  // verify() only enforces the structural invariants that must always hold for
+  // a class op to be meaningful. The stronger normal-form properties — a class
+  // result is never an operand of another class, and a class's operands are
+  // used only by the class — are *not* checked here: they are transiently
+  // broken by other ops' canonicalizations (e.g. `c1 + 0 -> c1` floats a class
+  // result into a class operand) and are the responsibility of the
+  // `equivalence-restore-invariants` normalization pass, not of well-formedness.
   if (getInputs().empty()) {
     return emitOpError("must have at least one operand");
   }
@@ -82,18 +89,6 @@ mlir::LogicalResult mlir::equivalence::ClassOp::verify() {
   for (Value operand : getInputs()) {
     if (!seen.insert(operand).second) {
       return emitOpError("operands must be unique");
-    }
-
-    Operation *defOp = operand.getDefiningOp();
-    if (defOp && isa<ClassOp>(defOp)) {
-      return emitOpError("result of a class operation cannot be used as an "
-                         "operand of another class");
-    }
-
-    for (Operation *user : operand.getUsers()) {
-      if (user != getOperation()) {
-        return emitOpError("operands must only be used by the class operation");
-      }
     }
   }
 
@@ -108,32 +103,22 @@ mlir::LogicalResult mlir::equivalence::ClassOp::verify() {
 }
 
 mlir::OpFoldResult mlir::equivalence::ClassOp::fold(FoldAdaptor adaptor) {
+  // fold() may only return an existing value or mutate *this* op in place. It
+  // must never create or mutate other operations — merging a nested class is
+  // such a foreign-op mutation, so it lives in canonicalize() instead.
+  //
   // Classes that participate in leader linkage are left untouched.
   if (getLeader())
     return {};
 
+  // A class that lists its own result as an operand: that operand is redundant
+  // and can be dropped in place.
   for (auto [idx, input] : llvm::enumerate(getInputs())) {
     auto innerClass = input.getDefiningOp<ClassOp>();
-    if (!innerClass)
-      continue;
     if (innerClass == getOperation()) {
-        getInputsMutable().erase(static_cast<unsigned>(idx));
-        return getResult();
+      getInputsMutable().erase(static_cast<unsigned>(idx));
+      return getResult();
     }
-
-    SmallVector<Value> merged = llvm::to_vector(innerClass.getInputs());
-    SmallPtrSet<Value, 8> seen(merged.begin(), merged.end());
-    for (auto [j, other] : llvm::enumerate(getInputs())) {
-      if (j == idx)
-        continue;
-      if (seen.insert(other).second)
-        merged.push_back(other);
-    }
-
-    // Operand indices change, so any precomputed selection is stale.
-    innerClass->removeAttr("min_cost_index");
-    innerClass.getInputsMutable().assign(merged);
-    return innerClass.getResult();
   }
 
   // Drop duplicate operands. A value appearing more than once adds nothing to
@@ -159,14 +144,48 @@ mlir::OpFoldResult mlir::equivalence::ClassOp::fold(FoldAdaptor adaptor) {
 mlir::LogicalResult
 mlir::equivalence::ClassOp::canonicalize(ClassOp op,
                                          PatternRewriter &rewriter) {
+  // Merge a nested e-class into this one. If an operand is itself the result of
+  // another class, the two classes denote the same equivalence set and can be
+  // collapsed: the inner class absorbs this class's remaining operands and this
+  // class is replaced by the inner class result. This is the structural rewrite
+  // that establishes "a class result is never an operand of another class".
+  //
+  // It mutates an operation other than `op` (the inner class), so it must go
+  // through the rewriter — that is precisely why it cannot live in fold(). Using
+  // modifyOpInPlace re-queues the inner class and notifies listeners.
+  if (!op.getLeader()) {
+    for (auto [idx, input] : llvm::enumerate(op.getInputs())) {
+      auto innerClass = input.getDefiningOp<ClassOp>();
+      if (!innerClass || innerClass == op.getOperation())
+        continue;
+
+      SmallVector<Value> merged = llvm::to_vector(innerClass.getInputs());
+      SmallPtrSet<Value, 8> seen(merged.begin(), merged.end());
+      for (auto [j, other] : llvm::enumerate(op.getInputs())) {
+        if (j == idx)
+          continue;
+        if (seen.insert(other).second)
+          merged.push_back(other);
+      }
+
+      rewriter.modifyOpInPlace(innerClass, [&] {
+        // Operand indices change, so any precomputed selection is stale.
+        innerClass->removeAttr("min_cost_index");
+        innerClass.getInputsMutable().assign(merged);
+      });
+      rewriter.replaceOp(op, innerClass.getResult());
+      return success();
+    }
+  }
+
   Value result = op.getResult();
   bool changed = false;
 
   // Every operand of an e-class is, by definition, equivalent to the class
   // itself. Any other operation that still refers to the operand directly
   // should instead route through the class result. Rewriting these uses
-  // establishes the invariant the verifier enforces: a class's operands are
-  // used only by the class operation.
+  // establishes the invariant that a class's operands are used only by the
+  // class operation.
   for (Value input : op.getInputs()) {
     rewriter.replaceUsesWithIf(input, result, [&](OpOperand &use) {
       if (use.getOwner() == op.getOperation())
@@ -206,6 +225,7 @@ namespace mlir::equivalence {
 #define GEN_PASS_DEF_EQUIVALENCESELECTCONSTANTS
 #define GEN_PASS_DEF_EQUIVALENCEEXTRACT
 #define GEN_PASS_DEF_EQUIVALENCEGRAPHSIZE
+#define GEN_PASS_DEF_EQUIVALENCERESTOREINVARIANTS
 #include "EquivalencePasses.h.inc"
 
 namespace {
@@ -358,6 +378,30 @@ public:
           inlineGraphOp(graphOp);
       }
     });
+  }
+};
+
+class EquivalenceRestoreInvariants
+    : public impl::EquivalenceRestoreInvariantsBase<
+          EquivalenceRestoreInvariants> {
+public:
+  using impl::EquivalenceRestoreInvariantsBase<
+      EquivalenceRestoreInvariants>::EquivalenceRestoreInvariantsBase;
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    ClassOp::getCanonicalizationPatterns(patterns, &getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+
+    // Run the class folder and canonicalizer to a genuine fixpoint. The cleanup
+    // (merge nested classes, reroute external uses) is a monotone rewrite, so
+    // lifting the greedy driver's iteration/rewrite caps lets it converge
+    // rather than bailing out after the default iteration budget.
+    GreedyRewriteConfig config;
+    config.setMaxIterations(GreedyRewriteConfig::kNoLimit);
+    config.setMaxNumRewrites(GreedyRewriteConfig::kNoLimit);
+
+    if (failed(applyPatternsGreedily(getOperation(), patternSet, config)))
+      signalPassFailure();
   }
 };
 

--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -97,14 +97,6 @@ mlir::LogicalResult mlir::equivalence::ClassOp::verify() {
 }
 
 mlir::OpFoldResult mlir::equivalence::ClassOp::fold(FoldAdaptor adaptor) {
-  // fold() may only return an existing value or mutate *this* op in place. It
-  // must never create or mutate other operations — merging a nested class is
-  // such a foreign-op mutation, so it lives in canonicalize() instead.
-  //
-  // Classes that participate in leader linkage are left untouched.
-  if (getLeader())
-    return {};
-
   // A class that lists its own result as an operand: that operand is redundant
   // and can be dropped in place.
   for (auto [idx, input] : llvm::enumerate(getInputs())) {
@@ -129,7 +121,7 @@ mlir::OpFoldResult mlir::equivalence::ClassOp::fold(FoldAdaptor adaptor) {
   }
 
   // A trivial e-class — a single input — is interchangeable with that input.
-  if (getInputs().size() == 1)
+  if (!getLeader() && (getInputs().size() == 1))
     return getInputs().front();
 
   return {};
@@ -143,10 +135,6 @@ mlir::equivalence::ClassOp::canonicalize(ClassOp op,
   // collapsed: the inner class absorbs this class's remaining operands and this
   // class is replaced by the inner class result. This is the structural rewrite
   // that establishes "a class result is never an operand of another class".
-  //
-  // It mutates an operation other than `op` (the inner class), so it must go
-  // through the rewriter — that is precisely why it cannot live in fold(). Using
-  // modifyOpInPlace re-queues the inner class and notifies listeners.
   if (!op.getLeader()) {
     for (auto [idx, input] : llvm::enumerate(op.getInputs())) {
       auto innerClass = input.getDefiningOp<ClassOp>();

--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -76,20 +76,14 @@ mlir::RegionKind GraphOp::getRegionKind(unsigned index) {
 mlir::LogicalResult mlir::equivalence::ClassOp::verify() {
   // verify() only enforces the structural invariants that must always hold for
   // a class op to be meaningful. The stronger normal-form properties — a class
-  // result is never an operand of another class, and a class's operands are
-  // used only by the class — are *not* checked here: they are transiently
-  // broken by other ops' canonicalizations (e.g. `c1 + 0 -> c1` floats a class
-  // result into a class operand) and are the responsibility of the
+  // result is never an operand of another class, a class's operands are used
+  // only by the class, and operands are unique — are *not* checked here: they
+  // are transiently broken by other ops' canonicalizations (e.g. `c1 + 0 -> c1`
+  // floats a class result into a class operand, and rerouting external uses can
+  // collapse two operands to the same value) and are the responsibility of the
   // `equivalence-restore-invariants` normalization pass, not of well-formedness.
   if (getInputs().empty()) {
     return emitOpError("must have at least one operand");
-  }
-
-  SmallPtrSet<Value, 8> seen;
-  for (Value operand : getInputs()) {
-    if (!seen.insert(operand).second) {
-      return emitOpError("operands must be unique");
-    }
   }
 
   if (Value leader = getLeader()) {

--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -156,6 +156,29 @@ mlir::OpFoldResult mlir::equivalence::ClassOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+mlir::LogicalResult
+mlir::equivalence::ClassOp::canonicalize(ClassOp op,
+                                         PatternRewriter &rewriter) {
+  Value result = op.getResult();
+  bool changed = false;
+
+  // Every operand of an e-class is, by definition, equivalent to the class
+  // itself. Any other operation that still refers to the operand directly
+  // should instead route through the class result. Rewriting these uses
+  // establishes the invariant the verifier enforces: a class's operands are
+  // used only by the class operation.
+  for (Value input : op.getInputs()) {
+    rewriter.replaceUsesWithIf(input, result, [&](OpOperand &use) {
+      if (use.getOwner() == op.getOperation())
+        return false;
+      changed = true;
+      return true;
+    });
+  }
+
+  return success(changed);
+}
+
 mlir::LogicalResult mlir::equivalence::GraphOp::verify() {
   auto walkResult = getBody().walk([&](Operation *op) -> WalkResult {
     if (isa<YieldOp>(op))

--- a/test/lit/canonicalize/restore-invariants.mlir
+++ b/test/lit/canonicalize/restore-invariants.mlir
@@ -1,0 +1,55 @@
+// RUN: tamagoyaki-opt --equivalence-restore-invariants %s | FileCheck %s
+
+// ===----------------------------------------------------------------------===//
+// Test the equivalence-restore-invariants pass.
+//
+// The pass re-establishes the class normal form to a fixpoint:
+//   * a class result is never an operand of another class (nested classes are
+//     merged), and
+//   * a class's operands are used only by that class (external uses are
+//     rerouted through the class result).
+//
+// These are no longer verifier invariants; they are transiently broken by
+// other ops' canonicalizations (here, `arith.addi %v, 0 -> %v` floats a class
+// result into a class operand) and restored by this pass.
+// ===----------------------------------------------------------------------===//
+
+// A nested class operand is absorbed and external operand uses are rerouted
+// through the class result. %extra uses both %a and %c, which are operands of
+// the merged class, so both uses are redirected to the class result.
+// CHECK-LABEL: func @nested_and_reroute
+// CHECK-SAME:    (%[[A:.*]]: i32, %[[B:.*]]: i32, %[[C:.*]]: i32)
+// CHECK-NEXT:    %[[CLS:.*]] = equivalence.class %[[A]], %[[B]], %[[C]] : i32
+// CHECK-NEXT:    %[[EXTRA:.*]] = arith.addi %[[CLS]], %[[CLS]] : i32
+// CHECK-NEXT:    return %[[CLS]], %[[EXTRA]] : i32, i32
+func.func @nested_and_reroute(%a: i32, %b: i32, %c: i32) -> (i32, i32) {
+  %zero = arith.constant 0 : i32
+  %inner = equivalence.class %a, %b : i32
+  %x = arith.addi %inner, %zero : i32
+  %O = equivalence.class %x, %c : i32
+  %extra = arith.addi %a, %c : i32
+  return %O, %extra : i32, i32
+}
+
+// The merged class drops its stale min_cost_index (operand indices shift).
+// CHECK-LABEL: func @merge_drops_min_cost_index
+// CHECK-NEXT:    %[[CLS:.*]] = equivalence.class %{{.*}}, %{{.*}}, %{{.*}} : i32
+// CHECK-NOT:     min_cost_index
+// CHECK-NEXT:    return %[[CLS]] : i32
+func.func @merge_drops_min_cost_index(%a: i32, %b: i32, %c: i32) -> i32 {
+  %zero = arith.constant 0 : i32
+  %inner = equivalence.class %a, %b (min_cost_index = 1) : i32
+  %x = arith.addi %inner, %zero : i32
+  %O = equivalence.class %x, %c : i32
+  return %O : i32
+}
+
+// Duplicate operands are not a verifier error; the pass deduplicates them.
+// CHECK-LABEL: func @duplicate_operands
+// CHECK-SAME:    (%[[A:.*]]: i32, %[[B:.*]]: i32)
+// CHECK-NEXT:    %[[CLS:.*]] = equivalence.class %[[A]], %[[B]] : i32
+// CHECK-NEXT:    return %[[CLS]] : i32
+func.func @duplicate_operands(%a: i32, %b: i32) -> i32 {
+  %c = equivalence.class %a, %b, %a : i32
+  return %c : i32
+}

--- a/test/lit/canonicalize/restore-invariants.mlir
+++ b/test/lit/canonicalize/restore-invariants.mlir
@@ -8,10 +8,7 @@
 //     merged), and
 //   * a class's operands are used only by that class (external uses are
 //     rerouted through the class result).
-//
-// These are no longer verifier invariants; they are transiently broken by
-// other ops' canonicalizations (here, `arith.addi %v, 0 -> %v` floats a class
-// result into a class operand) and restored by this pass.
+//   * class operands are deduplicated
 // ===----------------------------------------------------------------------===//
 
 // A nested class operand is absorbed and external operand uses are rerouted

--- a/test/lit/equivalence-ops-errors.mlir
+++ b/test/lit/equivalence-ops-errors.mlir
@@ -4,31 +4,18 @@
 // Test equivalence.class verification - error cases
 // ===----------------------------------------------------------------------===//
 
-// Test: class operand cannot be result of another class operation
-func.func @test_class_nested_class() {
-    %0 = arith.constant 1 : i32
-    %1 = equivalence.class %0 : i32
-    // expected-error@+1 {{result of a class operation cannot be used as an operand of another class}}
-    %2 = equivalence.class %1 : i32
-    return
-}
+// Note: several class properties are NOT verification errors — a class result
+// used as an operand of another class, a class operand reused by other ops, and
+// duplicate operands. They are transiently valid states broken by other ops'
+// canonicalizations; the `equivalence-restore-invariants` pass is responsible
+// for normalizing them. See test/lit/canonicalize/restore-invariants.mlir.
 
-// Test: class operand must only be used by the class operation
-func.func @test_class_operand_reuse() {
+// Test: leader must be the result of a class operation.
+func.func @test_class_bad_leader() {
     %0 = arith.constant 1 : i32
     %1 = arith.constant 2 : i32
-    // expected-error@+1 {{operands must only be used by the class operation}}
-    %2 = equivalence.class %0 : i32
-    %3 = arith.addi %0, %1 : i32
-    return
-}
-
-// Test: class operand used in multiple class operations
-func.func @test_class_operand_multiple_users() {
-    %0 = arith.constant 1 : i32
-    // expected-error@+1 {{operands must only be used by the class operation}}
-    %1 = equivalence.class %0 : i32
-    %2 = equivalence.class %0 : i32
+    // expected-error@+1 {{leader must be the result of a class operation}}
+    %2 = equivalence.class %0 leader %1 : i32
     return
 }
 

--- a/test/lit/equivalence-ops-errors.mlir
+++ b/test/lit/equivalence-ops-errors.mlir
@@ -4,12 +4,6 @@
 // Test equivalence.class verification - error cases
 // ===----------------------------------------------------------------------===//
 
-// Note: several class properties are NOT verification errors — a class result
-// used as an operand of another class, a class operand reused by other ops, and
-// duplicate operands. They are transiently valid states broken by other ops'
-// canonicalizations; the `equivalence-restore-invariants` pass is responsible
-// for normalizing them. See test/lit/canonicalize/restore-invariants.mlir.
-
 // Test: leader must be the result of a class operation.
 func.func @test_class_bad_leader() {
     %0 = arith.constant 1 : i32


### PR DESCRIPTION
Other passes (canonicalization, cse, ...) can break some of the
invariants expected for equality saturation. These invariants should not
be verified for the operation to be legal. Instead, a separate pass can
restore them.
