### PR TITLE
Fix stale cost

### DIFF
--- a/src/EquivalenceDialect.cpp
+++ b/src/EquivalenceDialect.cpp
@@ -484,8 +484,12 @@ computeGraphCosts(GraphOp graphOp, const NodeCostFn &nodeCostFn,
           cost = computeNodeCost(candidate, nodeCostFn, opCosts, reductionFn,
                                  costAttributeName);
           // Store candidate cost so callers can look it up.
-          if (cost >= 0)
-            opCosts.try_emplace(candidate, cost);
+          if (cost >= 0) {
+            auto it = opCosts.find(candidate);
+            if (it == opCosts.end() || cost < it->second) {
+              opCosts[candidate] = cost;
+            }
+          }
         }
         if (cost == -1)
           continue;

--- a/test/lit/greedy_select_stale_candidate_cost.mlir
+++ b/test/lit/greedy_select_stale_candidate_cost.mlir
@@ -1,0 +1,23 @@
+// RUN: tamagoyaki-opt "--equivalence-select-greedy=default-cost=1" %s | FileCheck %s
+
+// CHECK:      %[[Y:.*]] = equivalence.class %{{.*}}, %{{.*}} (min_cost_index = 1)
+// CHECK:      %[[C:.*]] = arith.addi %[[Y]], %arg0
+// CHECK:      equivalence.class %[[C]], %{{.*}} (min_cost_index = 0)
+
+func.func @main(%arg0: i32) -> i32 {
+  %0 = equivalence.graph -> (i32) {
+    %a_direct = arith.addi %arg0, %arg0 {equivalence.cost = #equivalence.cost<10>} : i32
+    %a_forward = arith.addi %z, %arg0 : i32
+    %y = equivalence.class %a_direct, %a_forward : i32
+
+    // Forward referenced from %a_forward such that the cost iterator has to run for multiple iterations
+    %z = arith.constant 1 : i32
+
+    %c = arith.addi %y, %arg0 : i32
+    %d = arith.addi %arg0, %arg0 {equivalence.cost = #equivalence.cost<5>} : i32
+
+    %x = equivalence.class %c, %d : i32
+    equivalence.yield %x : i32
+  }
+  return %0 : i32
+}


### PR DESCRIPTION
If the loop has to run for multiple iterations, e.g. due to forward references, then the costs for a single candidate may be recomputed but may not be lowered.
This is demonstrated in the test, where the real cost of %a_forward becomes lower than %a_direct, but this is not immediately visible.