### PR TITLE
Use union-by-rank to speed up getCanonicalLeader()

### DIFF
--- a/include/Utils/ClassOpUnionFind.h
+++ b/include/Utils/ClassOpUnionFind.h
@@ -16,6 +16,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
 
 namespace mlir::ematch {
 
@@ -115,6 +116,11 @@ public:
 private:
   SmallVector<equivalence::ClassOp> pendingErase;
   SmallVector<std::pair<mlir::Value, mlir::Value>> pendingClassUnions;
+
+  // Union by rank by out-of-IR lookup map.
+  // Since this only affects the union-by-rank heuristic, not correctness,
+  // no special handling is required for deletes / modifies.
+  llvm::DenseMap<mlir::Operation *, unsigned> unionRank;
 };
 
 } // namespace mlir::ematch

--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -166,8 +166,16 @@ void ClassOpUnionFind::classUnion(mlir::PatternRewriter &rewriter,
   if (leader == other)
     return;
 
+  unsigned rankLeader = unionRank.lookup(leader.getOperation());
+  unsigned rankOther = unionRank.lookup(other.getOperation());
+
+  if (rankLeader < rankOther)
+    std::swap(leader, other);
+
   // Lazy union: just point `other` at `leader` via the leader operand.
   other.getLeaderMutable().assign(leader.getResult());
+  if (rankLeader == rankOther)
+    unionRank[leader.getOperation()] = rankLeader + 1;
 
   // We push `other` such that at the start of `rebuild`,
   worklist.push_back(other);


### PR DESCRIPTION
Keep the map out-of-IR to keep things clean.
Since this is only a heuristic, we don't need to do anything special on erases or modifications.

```
Benchmark 1: build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
  Time (mean ± σ):      8.395 s ±  0.075 s    [User: 8.246 s, System: 0.116 s]
  Range (min … max):    8.314 s …  8.556 s    10 runs

Benchmark 2: build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
  Time (mean ± σ):      8.014 s ±  0.095 s    [User: 7.864 s, System: 0.122 s]
  Range (min … max):    7.887 s …  8.136 s    10 runs

Summary
  build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing ran
    1.05 ± 0.02 times faster than build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
```

Not a whole lot faster, but still faster on rebuild, and given this is basically a freebie, it seems worth it.