### PR TITLE
Use tombstone-free DenseMap for more recent MLIR versions

### DIFF
--- a/vendor/mlir/SimpleOperationInfo.h
+++ b/vendor/mlir/SimpleOperationInfo.h
@@ -25,8 +25,7 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
     auto *rhs = const_cast<Operation *>(rhsC);
     if (lhs == rhs)
       return true;
-    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
-        rhs == getTombstoneKey() || rhs == getEmptyKey())
+    if (!lhs || !rhs)
       return false;
     return OperationEquivalence::isEquivalentTo(
         const_cast<Operation *>(lhsC), const_cast<Operation *>(rhsC),


### PR DESCRIPTION
As of a few weeks ago, LLVM removed the tombstone key from DenseMapInfo

Cf. https://github.com/llvm/llvm-project/pull/200959 for example.

This was a patch needed to get the Tamagoyaki build working with HEIR, figured I could upstream it.