### PR TITLE
Speed up swappedErase()

### DIFF
--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -105,15 +105,26 @@ mlir::ematch::getClassResults(mlir::PatternRewriter &rewriter,
 // Instead of using erase directly, it first swaps with the last element to make
 // erase O(1).
 static void swappedErase(equivalence::ClassOp classOp, Value target) {
-  auto inputs = classOp.getInputs();
-  unsigned last = inputs.size() - 1; // inclusive
-  for (unsigned i = 0; i <= last; ++i) {
-    if (inputs[i] == target) {
-      if (i != last)
-        classOp->setOperand(i, inputs[last]);
-      classOp.getInputsMutable().erase(last);
-      return;
-    }
+  auto inputs = classOp.getInputsMutable();
+
+  // Instead of searching the operand in the inputs, which is O(#inputs),
+  // search it from the uses.
+  // Since the uses are limited by the number of classes, this is cheaper.
+  for (auto &use : target.getUses()) {
+    if (use.getOwner() != classOp.getOperation())
+      continue;
+
+    unsigned i = use.getOperandNumber();
+    // Check whether it's an actual input, and not a leader.
+    if (i >= inputs.size())
+      continue;
+
+    // Perform actual swap-erase.
+    unsigned last = inputs.size() - 1;
+    if (i != last)
+      classOp->setOperand(i, inputs[last].get());
+    inputs.erase(last);
+    return;
   }
 }
 


### PR DESCRIPTION
Instead of looping through the inputs to find the position, go from the uses which will be O(#classes) instead of O(#inputs).

```
Benchmark 1: build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
  Time (mean ± σ):      8.300 s ±  0.089 s    [User: 8.140 s, System: 0.125 s]
  Range (min … max):    8.170 s …  8.465 s    10 runs

Benchmark 2: build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
  Time (mean ± σ):      7.168 s ±  0.109 s    [User: 7.011 s, System: 0.125 s]
  Range (min … max):    7.006 s …  7.331 s    10 runs

Summary
  build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing ran
    1.16 ± 0.02 times faster than build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
```