### PR TITLE
Use batched append in rebuilding

### DIFF
--- a/src/Utils/ClassOpUnionFind.cpp
+++ b/src/Utils/ClassOpUnionFind.cpp
@@ -276,6 +276,9 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
     // Deduplicate sets for operand merging keyed by leader op.
     // Shared across all ClassOps merging into the same leader.
     llvm::DenseMap<Operation *, llvm::SmallPtrSet<Value, 16>> leaderExisting;
+    // Operands to append to each leader, built across every ClassOp that merges into it.
+    // Allows for a batched append which will avoid repeated operand list resizes.
+    llvm::DenseMap<equivalence::ClassOp, SmallVector<Value>> leaderNewOperands;
     SmallVector<Operation *> current;
     std::swap(current, worklist);
     for (Operation *op : current) {
@@ -301,17 +304,15 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
           it->second.insert(leader.getInputs().begin(),
                             leader.getInputs().end());
         auto &existing = it->second;
+        auto &pending = leaderNewOperands[leader]; // Note: this access may make empty lists
 
-        SmallVector<Value, 8> newOperands;
         for (Value operand : c.getInputs()) {
           assert(
               !operand.getDefiningOp() ||
               !llvm::dyn_cast<equivalence::ClassOp>(operand.getDefiningOp()));
           if (existing.insert(operand).second)
-            newOperands.push_back(operand);
+            pending.push_back(operand);
         }
-        auto mutableInputs = leader.getInputsMutable();
-        mutableInputs.append(newOperands);
 
         // update all users of c
         rewriter.replaceAllUsesWith(c.getResult(), leader.getResult());
@@ -323,6 +324,12 @@ bool ClassOpUnionFind::rebuild(HashConsPatternRewriter &rewriter) {
         pendingErase.push_back(c);
       }
       todo.insert(leader.getOperation());
+    }
+
+    // Batched append.
+    for (auto &[leaderClass, operands] : leaderNewOperands) {
+      if (!operands.empty())
+        leaderClass.getInputsMutable().append(operands);
     }
 
     for (Operation *op : todo) {


### PR DESCRIPTION
The code already did a batched append in the inner loop, but we can move that to the outer loop. This avoids repeated list resizes which showed up in the profile.

Benched on top of the swappedErase improvement:
```
Benchmark 1: build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
  Time (mean ± σ):      7.134 s ±  0.061 s    [User: 6.980 s, System: 0.118 s]
  Range (min … max):    7.008 s …  7.209 s    10 runs

Benchmark 2: build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
  Time (mean ± σ):      6.891 s ±  0.087 s    [User: 6.741 s, System: 0.121 s]
  Range (min … max):    6.797 s …  7.108 s    10 runs

Summary
  build/bin/tamagoyaki-opt input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing ran
    1.04 ± 0.02 times faster than build/bin/tamagoyaki-opt-old input.mlir -equivalence-insert-graph --ematch-saturate="patterns-file=patterns.mlir max-iters=8" -mlir-timing
```