### PR TITLE
Use isa<> instead of dyn_cast<> when result is unused

### DIFF
--- a/src/Utils/HashConsPatternRewriter.cpp
+++ b/src/Utils/HashConsPatternRewriter.cpp
@@ -31,7 +31,7 @@ HashConsPatternRewriter::HashConsPatternRewriter(MLIRContext *ctx)
 void HashConsPatternRewriter::startOpModification(Operation *op) {
   LLVM_DEBUG(llvm::dbgs() << "operation being modified (start): " << *op
                           << "\n");
-  if (dyn_cast<equivalence::ClassOp>(*op))
+  if (isa<equivalence::ClassOp>(*op))
     return;
   (void)erase(op);
   PatternRewriter::startOpModification(op);
@@ -40,7 +40,7 @@ void HashConsPatternRewriter::startOpModification(Operation *op) {
 void HashConsPatternRewriter::cancelOpModification(Operation *op) {
   LLVM_DEBUG(llvm::dbgs() << "operation being modified (cancel): " << *op
                           << "\n");
-  if (dyn_cast<equivalence::ClassOp>(*op))
+  if (isa<equivalence::ClassOp>(*op))
     return;
   (void)insert(op);
   PatternRewriter::cancelOpModification(op);
@@ -49,7 +49,7 @@ void HashConsPatternRewriter::cancelOpModification(Operation *op) {
 void HashConsPatternRewriter::finalizeOpModification(Operation *op) {
   LLVM_DEBUG(llvm::dbgs() << "operation being modified (finalize): " << *op
                           << "\n");
-  if (dyn_cast<equivalence::ClassOp>(*op))
+  if (isa<equivalence::ClassOp>(*op))
     return;
   if (failed(insert(op)) && unionFind) {
     unionFind->repairDuplicate(op);


### PR DESCRIPTION
Cleaner, and perhaps a bit faster.